### PR TITLE
Add StartGame logging and network callback instrumentation

### DIFF
--- a/Assets/Scripts/BasicSpawner.cs
+++ b/Assets/Scripts/BasicSpawner.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using static Corris.Loggers.Logger;
@@ -39,6 +40,9 @@ public class BasicSpawner : MonoBehaviour, INetworkRunnerCallbacks
 
     private Dictionary<PlayerRef, List<NetworkObject>> _spawnedPlayers = new();
 
+    // Prevent multiple connection attempts
+    private bool _isConnecting = false;
+
     private void Awake()
     {
         // Singleton setup
@@ -52,7 +56,7 @@ public class BasicSpawner : MonoBehaviour, INetworkRunnerCallbacks
         DontDestroyOnLoad(gameObject); // Preserve between scenes
     }
 
-    async void StartGame(GameMode mode)
+    private async Task StartGame(GameMode mode)
     {
         // Test if _UnitPrefab initialized
         if (_UnitPrefab == null)
@@ -73,14 +77,25 @@ public class BasicSpawner : MonoBehaviour, INetworkRunnerCallbacks
             sceneInfo.AddSceneRef(scene, LoadSceneMode.Additive);
         }
 
-        // Start or join (depends on gamemode) a session with a specific name
-        await _NetRunner.StartGame(new StartGameArgs()
+        Log($"{GetLogCallPrefix(GetType())} StartGame initiated for {mode}");
+
+        try
         {
-            GameMode = mode,
-            SessionName = "TestRoom",
-            Scene = scene,
-            SceneManager = gameObject.AddComponent<NetworkSceneManagerDefault>()
-        });
+            var result = await _NetRunner.StartGame(new StartGameArgs()
+            {
+                GameMode = mode,
+                SessionName = "TestRoom",
+                Scene = scene,
+                SceneManager = gameObject.AddComponent<NetworkSceneManagerDefault>()
+            });
+
+            Log($"{GetLogCallPrefix(GetType())} StartGame result: Ok={result.Ok}, ShutdownReason={result.ShutdownReason}, ErrorMessage={result.ErrorMessage}");
+        }
+        catch (Exception ex)
+        {
+            LogError($"{GetLogCallPrefix(GetType())} StartGame exception: {ex.Message}");
+            return;
+        }
 
         #region LogAccessTo NetRunner.Tick
         // Provide the logger with a way to get the current server tick safely
@@ -99,25 +114,38 @@ public class BasicSpawner : MonoBehaviour, INetworkRunnerCallbacks
 
     }
 
+    private async void StartGameAsync(GameMode mode)
+    {
+        if (_isConnecting) return;
 
+        _isConnecting = true;
+
+        await StartGame(mode);
+
+        _isConnecting = false;
+    }
 
     private void OnGUI()
     {
+        GUI.enabled = !_isConnecting;
+
         float buttonY = 0f;
 
         if (_NetRunner == null)
         {
             if (GUI.Button(new Rect(0, 0, 200, 40), "Host"))
             {
-                StartGame(GameMode.Host);
+                StartGameAsync(GameMode.Host);
             }
             if (GUI.Button(new Rect(0, 40, 200, 40), "Join"))
             {
-                StartGame(GameMode.Client);
+                StartGameAsync(GameMode.Client);
             }
 
             buttonY = 80f;
         }
+
+        GUI.enabled = true;
 
         if (GUI.Button(new Rect(0, buttonY, 200, 40), "Exit"))
         {
@@ -266,21 +294,21 @@ public class BasicSpawner : MonoBehaviour, INetworkRunnerCallbacks
     }
 
     #region INetworkRunnerCallbacks Implementation
-    public void OnInputMissing(NetworkRunner runner, PlayerRef player, NetworkInput input) { }
-    public void OnShutdown(NetworkRunner runner, ShutdownReason shutdownReason) { }
-    public void OnConnectedToServer(NetworkRunner runner) { }
-    public void OnDisconnectedFromServer(NetworkRunner runner, NetDisconnectReason reason) { }
-    public void OnConnectRequest(NetworkRunner runner, NetworkRunnerCallbackArgs.ConnectRequest request, byte[] token) { }
-    public void OnConnectFailed(NetworkRunner runner, NetAddress remoteAddress, NetConnectFailedReason reason) { }
-    public void OnUserSimulationMessage(NetworkRunner runner, SimulationMessagePtr message) { }
-    public void OnSessionListUpdated(NetworkRunner runner, List<SessionInfo> sessionList) { }
-    public void OnCustomAuthenticationResponse(NetworkRunner runner, Dictionary<string, object> data) { }
-    public void OnHostMigration(NetworkRunner runner, HostMigrationToken hostMigrationToken) { }
-    public void OnSceneLoadStart(NetworkRunner runner) { }
-    public void OnObjectExitAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { }
-    public void OnObjectEnterAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { }
-    public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ReliableKey key, ArraySegment<byte> data) { }
-    public void OnReliableDataProgress(NetworkRunner runner, PlayerRef player, ReliableKey key, float progress) { }
+    public void OnInputMissing(NetworkRunner runner, PlayerRef player, NetworkInput input) { Log($"{GetLogCallPrefix(GetType())} OnInputMissing triggered"); }
+    public void OnShutdown(NetworkRunner runner, ShutdownReason shutdownReason) { Log($"{GetLogCallPrefix(GetType())} OnShutdown triggered"); }
+    public void OnConnectedToServer(NetworkRunner runner) { Log($"{GetLogCallPrefix(GetType())} OnConnectedToServer triggered"); }
+    public void OnDisconnectedFromServer(NetworkRunner runner, NetDisconnectReason reason) { Log($"{GetLogCallPrefix(GetType())} OnDisconnectedFromServer triggered"); }
+    public void OnConnectRequest(NetworkRunner runner, NetworkRunnerCallbackArgs.ConnectRequest request, byte[] token) { Log($"{GetLogCallPrefix(GetType())} OnConnectRequest triggered"); }
+    public void OnConnectFailed(NetworkRunner runner, NetAddress remoteAddress, NetConnectFailedReason reason) { Log($"{GetLogCallPrefix(GetType())} OnConnectFailed triggered"); }
+    public void OnUserSimulationMessage(NetworkRunner runner, SimulationMessagePtr message) { Log($"{GetLogCallPrefix(GetType())} OnUserSimulationMessage triggered"); }
+    public void OnSessionListUpdated(NetworkRunner runner, List<SessionInfo> sessionList) { Log($"{GetLogCallPrefix(GetType())} OnSessionListUpdated triggered"); }
+    public void OnCustomAuthenticationResponse(NetworkRunner runner, Dictionary<string, object> data) { Log($"{GetLogCallPrefix(GetType())} OnCustomAuthenticationResponse triggered"); }
+    public void OnHostMigration(NetworkRunner runner, HostMigrationToken hostMigrationToken) { Log($"{GetLogCallPrefix(GetType())} OnHostMigration triggered"); }
+    public void OnSceneLoadStart(NetworkRunner runner) { Log($"{GetLogCallPrefix(GetType())} OnSceneLoadStart triggered"); }
+    public void OnObjectExitAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { Log($"{GetLogCallPrefix(GetType())} OnObjectExitAOI triggered"); }
+    public void OnObjectEnterAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { Log($"{GetLogCallPrefix(GetType())} OnObjectEnterAOI triggered"); }
+    public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ReliableKey key, ArraySegment<byte> data) { Log($"{GetLogCallPrefix(GetType())} OnReliableDataReceived triggered"); }
+    public void OnReliableDataProgress(NetworkRunner runner, PlayerRef player, ReliableKey key, float progress) { Log($"{GetLogCallPrefix(GetType())} OnReliableDataProgress triggered"); }
     #endregion
 
     public void HandleDestinationInput(Vector3 targetPosition)


### PR DESCRIPTION
## Summary
- add detailed StartGame logs and exception handling
- guard StartGame with connection state and keep OnGUI synchronous
- log every Fusion network callback for startup tracing

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_688df28e8ca4832089cd8d68351508ca