### PR TITLE
Add connection status panel

### DIFF
--- a/Assets/Scripts/BasicSpawner.cs
+++ b/Assets/Scripts/BasicSpawner.cs
@@ -122,7 +122,16 @@ public class BasicSpawner : MonoBehaviour, INetworkRunnerCallbacks
         try
         {
             _isConnecting = true;
+            Panel_Status.Instance.StartConnecting();
             await StartGame(mode);
+            if (_NetRunner != null && _NetRunner.IsRunning)
+            {
+                Panel_Status.Instance.SetConnected();
+            }
+            else
+            {
+                Panel_Status.Instance.SetUnconnected();
+            }
         }
         finally
         {

--- a/Assets/Scripts/Panel_Status.cs
+++ b/Assets/Scripts/Panel_Status.cs
@@ -1,16 +1,79 @@
 using UnityEngine;
+using TMPro;
+using System.Collections;
 
 public class Panel_Status : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    public static Panel_Status Instance { get; private set; }
+
+    [SerializeField] private TMP_Text _statusText;
+    [SerializeField] private Color _colorUnconnected = Color.white;
+    [SerializeField] private Color _colorConnecting = Color.yellow;
+    [SerializeField] private Color _colorConnected = Color.green;
+
+    private Coroutine _connectingRoutine;
+
+    private void Awake()
     {
-        
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+
+        if (_statusText == null)
+        {
+            _statusText = GetComponentInChildren<TMP_Text>();
+        }
     }
 
-    // Update is called once per frame
-    void Update()
+    private void Start()
     {
-        
+        SetUnconnected();
+    }
+
+    public void SetUnconnected()
+    {
+        StopConnectingAnimation();
+        _statusText.text = "Unconnected";
+        _statusText.color = _colorUnconnected;
+    }
+
+    public void StartConnecting()
+    {
+        StopConnectingAnimation();
+        _connectingRoutine = StartCoroutine(ConnectingAnimation());
+    }
+
+    public void SetConnected()
+    {
+        StopConnectingAnimation();
+        _statusText.text = "Connected";
+        _statusText.color = _colorConnected;
+    }
+
+    private IEnumerator ConnectingAnimation()
+    {
+        _statusText.color = _colorConnecting;
+        const string baseText = "Connecting";
+        int dots = 0;
+        while (true)
+        {
+            _statusText.text = baseText + new string('.', dots);
+            dots = (dots + 1) % 4;
+            yield return new WaitForSeconds(0.5f);
+        }
+    }
+
+    private void StopConnectingAnimation()
+    {
+        if (_connectingRoutine != null)
+        {
+            StopCoroutine(_connectingRoutine);
+            _connectingRoutine = null;
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- animate status panel during connection attempt
- update status colors for unconnected, connecting, and connected states

## Testing
- `dotnet test` *(fails: MSB1003 Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688e1d85515483209bf157347b9cc64b