### PR TITLE
Disable UI during unit selection

### DIFF
--- a/Assets/Scripts/GameLauncher.cs
+++ b/Assets/Scripts/GameLauncher.cs
@@ -28,12 +28,13 @@ public class GameLauncher : MonoBehaviour
         }
 
         float exitButtonY = 0f;
+        bool selectionActive = SelectionManager.IsSelecting;
 
         // Only draw the Host and Join buttons if the network runner has not been created yet.
         if (networkManager.NetRunner == null)
         {
-            // Disable buttons if a connection is currently in progress.
-            GUI.enabled = !networkManager.IsConnecting;
+            // Disable buttons if a connection is currently in progress or a selection is active.
+            GUI.enabled = !networkManager.IsConnecting && !selectionActive;
 
             if (GUI.Button(new Rect(0, 0, 200, 40), "Host"))
             {
@@ -48,12 +49,13 @@ public class GameLauncher : MonoBehaviour
             exitButtonY = 80f;
         }
 
-        // Always show and enable the Exit button.
-        GUI.enabled = true;
+        // Always show the Exit button but disable it during selection.
+        GUI.enabled = !selectionActive;
         if (GUI.Button(new Rect(0, exitButtonY, 200, 40), "Exit"))
         {
             QuitGame();
         }
+        GUI.enabled = true;
     }
 
     private void QuitGame()

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -53,6 +53,7 @@ public class SelectionManager : MonoBehaviour
 
     public void UpdateSelection(Vector2 currentPosition)
     {
+        if (!IsSelecting) return;
         // Convert current position to local coordinates of the Canvas
         RectTransformUtility.ScreenPointToLocalPointInRectangle(_canvasRect, currentPosition, mainCamera, out Vector2 localPoint);
 
@@ -64,15 +65,28 @@ public class SelectionManager : MonoBehaviour
 
     public void EndSelection()
     {
+        if (!IsSelecting) return;
         selectionBox.gameObject.SetActive(false);
 
-        // Select new units
-        SelectUnits(NetworkGameManager.Instance.NetRunner.LocalPlayer);
+        SelectUnits();
         IsSelecting = false;
     }
 
-    private void SelectUnits(PlayerRef localPlayer)
+    private void SelectUnits()
     {
+        if (NetworkGameManager.Instance.NetRunner == null)
+        {
+            LogError($"{GetLogCallPrefix(GetType())} NetRunner is null. Cannot select units.");
+            return;
+        }
+        if (selectionBox == null || mainCamera == null)
+        {
+            LogError($"{GetLogCallPrefix(GetType())} Selection box or main camera is not set.");
+            return;
+        }
+
+        PlayerRef localPlayer = NetworkGameManager.Instance.NetRunner.LocalPlayer;
+
         // Clear previous selection
         foreach (var unit in _selectedUnits)
         {

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -17,6 +17,9 @@ public class SelectionManager : MonoBehaviour
     [SerializeField] private List<Unit> _selectedUnits = new();
     public List<Unit> SelectedUnits => _selectedUnits;
 
+    // Indicates whether a frame selection is currently active
+    public static bool IsSelecting { get; private set; }
+
     public void Start()
     {
         _canvasRect = selectionBox.GetComponentInParent<Canvas>().GetComponent<RectTransform>();
@@ -45,6 +48,7 @@ public class SelectionManager : MonoBehaviour
         _startPosition = localPoint;
 
         selectionBox.gameObject.SetActive(true);
+        IsSelecting = true;
     }
 
     public void UpdateSelection(Vector2 currentPosition)
@@ -64,6 +68,7 @@ public class SelectionManager : MonoBehaviour
 
         // Select new units
         SelectUnits(NetworkGameManager.Instance.NetRunner.LocalPlayer);
+        IsSelecting = false;
     }
 
     private void SelectUnits(PlayerRef localPlayer)


### PR DESCRIPTION
## Summary
- expose selection state through SelectionManager
- disable main menu buttons while selecting units

## Testing
- `dotnet test` *(fails: MSBUILD error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6890d9fe9cd483208dcaf79fc44c5d38