### PR TITLE
Replace IsOwnedBy with CanBeSelectedBy

### DIFF
--- a/Assets/Scripts/ISelectable.cs
+++ b/Assets/Scripts/ISelectable.cs
@@ -11,9 +11,9 @@ public interface ISelectable
     bool Selected { get; set; }
 
     /// <summary>
-    /// Checks if the object belongs to the specified player.
+    /// Determines whether the object can be selected by the specified player.
     /// </summary>
-    /// <param name="player">Player to check ownership against.</param>
-    /// <returns>True if owned by the player, otherwise false.</returns>
-    bool IsOwnedBy(PlayerRef player);
+    /// <param name="player">Player attempting the selection.</param>
+    /// <returns>True if selection is allowed, otherwise false.</returns>
+    bool CanBeSelectedBy(PlayerRef player);
 }

--- a/Assets/Scripts/Selectable.cs
+++ b/Assets/Scripts/Selectable.cs
@@ -45,7 +45,18 @@ public class Selectable : NetworkBehaviour, ISelectable
     }
 
     /// <summary>
-    /// Checks if the unit belongs to the specified player.
+    /// Determines if the unit can be selected by the specified player.
     /// </summary>
-    public bool IsOwnedBy(PlayerRef player) => _unit != null && _unit.PlayerOwner == player;
+    /// <param name="player">Player attempting the selection.</param>
+    /// <returns>True if the player is allowed to select the unit.</returns>
+    public bool CanBeSelectedBy(PlayerRef player)
+    {
+        if (_unit == null)
+        {
+            return false;
+        }
+
+        // Currently selection is allowed only for the owner. Extend this logic to include allies if needed.
+        return _unit.PlayerOwner == player;
+    }
 }

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -122,7 +122,7 @@ public class SelectionManager : MonoBehaviour
 
             if (selectionBox_Screen.Contains(unitPosition_Screen))
             {
-                if (selectable.IsOwnedBy(localPlayer))
+                if (selectable.CanBeSelectedBy(localPlayer))
                 {
                     selectable.Selected = true;
                     _selectedUnits.Add(selectable);


### PR DESCRIPTION
## Summary
- expose `CanBeSelectedBy` on selectable units
- restrict selection based on `CanBeSelectedBy`
- allow extension for broader selection rules

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689471dc6e888320b06c73357a3d077e