### PR TITLE
Introduce selectable provider architecture

### DIFF
--- a/Assets/Scripts/ISelectable.cs.meta
+++ b/Assets/Scripts/ISelectable.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
-guid: c7998c6471db4ce9826295771008cb64
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+guid: 525baa1c231e4d31b34ea7080dda2f2a

--- a/Assets/Scripts/ISelectableProvider.cs
+++ b/Assets/Scripts/ISelectableProvider.cs
@@ -1,0 +1,10 @@
+/// <summary>
+/// Provides access to an <see cref="ISelectable"/> instance.
+/// </summary>
+public interface ISelectableProvider
+{
+    /// <summary>
+    /// Returns the selectable instance associated with the object.
+    /// </summary>
+    ISelectable Selectable { get; }
+}

--- a/Assets/Scripts/ISelectableProvider.cs.meta
+++ b/Assets/Scripts/ISelectableProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c61ae8380614c0a90023707ed92e365

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -69,20 +69,13 @@ public class PlayerManager : MonoBehaviour
             for (int i = 0; i < data.unitCount; i++)
             {
                 var selectable = _selectionManager.SelectedUnits[i];
-                if (selectable is MonoBehaviour component)
+                if (selectable is NetworkBehaviour nb)
                 {
-                    if (component.TryGetComponent<NetworkObject>(out var networkObject))
-                    {
-                        data.unitIds[i] = networkObject.Id.Raw;
-                    }
-                    else
-                    {
-                        LogError($"{GetLogCallPrefix(GetType())} Unit {component.name} is missing a NetworkObject!");
-                    }
+                    data.unitIds[i] = nb.Object.Id.Raw;
                 }
-                else
+                else if (selectable is Component component)
                 {
-                    LogError($"{GetLogCallPrefix(GetType())} Selected object at index {i} is not a MonoBehaviour!");
+                    LogError($"{GetLogCallPrefix(GetType())} Unit {component.name} is missing a NetworkObject!");
                 }
             }
 

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -117,7 +117,13 @@ public class SelectionManager : MonoBehaviour
 
         foreach (var unit in UnitRegistry.Units.Values)
         {
-            if (!unit.TryGetComponent<Selectable>(out var selectable))
+            if (unit is not ISelectableProvider provider)
+            {
+                continue;
+            }
+
+            var selectable = provider.Selectable;
+            if (selectable == null)
             {
                 continue;
             }
@@ -126,14 +132,14 @@ public class SelectionManager : MonoBehaviour
 
             Rect selectionBox_Screen = GetRectFromPoints(leftTop_Screen, rightBottom_Screeen);
 
-            if (selectionBox_Screen.Contains(unitPosition_Screen))
+            if (selectionBox_Screen.Contains(unitPosition_Screen) && selectable.CanBeSelectedBy(localPlayer))
             {
-                if (selectable.CanBeSelectedBy(localPlayer))
-                {
-                    selectable.Selected = true;
-                    _selectedUnits.Add(selectable);
+                selectable.Selected = true;
+                _selectedUnits.Add(selectable);
 
-                    Log($"{GetLogCallPrefix(GetType())} Unit selected: {selectable.name}");
+                if (selectable is Component component)
+                {
+                    Log($"{GetLogCallPrefix(GetType())} Unit selected: {component.name}");
                 }
             }
         }

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -8,10 +8,12 @@ using static Corris.Loggers.LogUtils;
 /// <summary>
 /// Unit class represents a controllable unit in the game.
 /// </summary>
-public class Unit : NetworkBehaviour, IPositionable
+[RequireComponent(typeof(Selectable))]
+public class Unit : NetworkBehaviour, IPositionable, ISelectableProvider
 {
     public GameObject body;
     private NetworkCharacterController _cc;
+    private ISelectable _selectable;
 
     /// <summary>
     /// Material index, for passing to other clients via RPC
@@ -31,6 +33,11 @@ public class Unit : NetworkBehaviour, IPositionable
 
     // Last server tick for processed command (defense from "old commands" being processed)
     private float lastCommandServerTick;
+
+    /// <summary>
+    /// Provides access to the Selectable component associated with this unit.
+    /// </summary>
+    public ISelectable Selectable => _selectable ??= GetComponent<Selectable>();
 
     public override void Spawned()
     {


### PR DESCRIPTION
## Summary
- define `ISelectable` for selection behavior and `ISelectableProvider` to expose it
- require units to provide a `Selectable` component and work with interfaces in selection manager
- gather network unit IDs by casting selected interfaces to `NetworkBehaviour`

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_6894753e5e8883209ed2faab0c9c275b