### PR TITLE
Register player cursors on spawn

### DIFF
--- a/Assets/Scripts/PlayerCursor.cs
+++ b/Assets/Scripts/PlayerCursor.cs
@@ -7,5 +7,12 @@ using UnityEngine;
 public class PlayerCursor : NetworkBehaviour
 {
     [Networked] public Vector3 CursorPosition { get; set; }
+
+    public override void Spawned()
+    {
+        base.Spawned();
+        // Register this cursor with the PlayerManager when it spawns.
+        FindObjectOfType<PlayerManager>()?.RegisterPlayerCursor(Object.InputAuthority, this);
+    }
 }
 

--- a/Assets/Scripts/PlayerCursor.cs
+++ b/Assets/Scripts/PlayerCursor.cs
@@ -12,7 +12,7 @@ public class PlayerCursor : NetworkBehaviour
     {
         base.Spawned();
         // Register this cursor with the PlayerManager when it spawns.
-        FindObjectOfType<PlayerManager>()?.RegisterPlayerCursor(Object.InputAuthority, this);
+        ConnectionManager.Instance.PlayerManager?.RegisterPlayerCursor(Object.InputAuthority, this);
     }
 }
 

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -100,13 +100,18 @@ public class PlayerManager : NetworkBehaviour
 
     private void UpdateCursorsEcho()
     {
-        foreach (var pair in _playerCursors)
+        foreach (var cursor in _playerCursors.Values)
         {
-            if (_playerCursors.TryGetValue(pair.Key, out var cursor))
-            {
-                pair.Value.transform.position = cursor.CursorPosition;
-            }
+            cursor.transform.position = cursor.CursorPosition;
         }
+    }
+
+    /// <summary>
+    /// Registers a player cursor so its position can be updated.
+    /// </summary>
+    public void RegisterPlayerCursor(PlayerRef player, PlayerCursor cursor)
+    {
+        _playerCursors[player] = cursor;
     }
 
     public bool TryGetPlayerCursor(PlayerRef player, out PlayerCursor cursor)
@@ -185,7 +190,7 @@ public class PlayerManager : NetworkBehaviour
             if (PlayerCursorPrefab != null)
             {
                 var cursor = runner.Spawn(PlayerCursorPrefab, Vector3.zero, Quaternion.identity, player);
-                _playerCursors[player] = cursor;
+                RegisterPlayerCursor(player, cursor);
             }
             else
             {

--- a/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -33,24 +33,24 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 2644742391991631933
-      - rid: 2644742391991631934
+      - rid: 2644742391991631944
+      - rid: 2644742391991631945
       - rid: 6852985685364965378
       - rid: 6852985685364965379
       - rid: 6852985685364965380
       - rid: 6852985685364965381
-      - rid: 2644742391991631935
-      - rid: 2644742391991631936
+      - rid: 2644742391991631946
+      - rid: 2644742391991631947
       - rid: 6852985685364965384
       - rid: 6852985685364965385
-      - rid: 2644742391991631937
-      - rid: 2644742391991631938
-      - rid: 2644742391991631939
-      - rid: 2644742391991631940
-      - rid: 2644742391991631941
-      - rid: 2644742391991631942
+      - rid: 2644742391991631948
+      - rid: 2644742391991631949
+      - rid: 2644742391991631950
+      - rid: 2644742391991631951
+      - rid: 2644742391991631952
+      - rid: 2644742391991631953
       - rid: 6852985685364965392
-      - rid: 2644742391991631943
+      - rid: 2644742391991631954
       - rid: 6852985685364965394
       - rid: 8712630790384254976
       - rid: 196572100355162112
@@ -102,14 +102,14 @@ MonoBehaviour:
         m_xrOcclusionMeshPS: {fileID: 4800000, guid: 4431b1f1f743fbf4eb310a967890cbea, type: 3}
         m_xrMirrorViewPS: {fileID: 4800000, guid: d5a307c014552314b9f560906d708772, type: 3}
         m_xrMotionVector: {fileID: 4800000, guid: f89aac1e4f84468418fe30e611dff395, type: 3}
-    - rid: 2644742391991631933
+    - rid: 2644742391991631944
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 1
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 2644742391991631934
+    - rid: 2644742391991631945
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -121,7 +121,7 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 2644742391991631935
+    - rid: 2644742391991631946
       type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -136,7 +136,7 @@ MonoBehaviour:
         m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
         m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
         m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 2644742391991631936
+    - rid: 2644742391991631947
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -144,7 +144,7 @@ MonoBehaviour:
         m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
-    - rid: 2644742391991631937
+    - rid: 2644742391991631948
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -157,13 +157,13 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 2644742391991631938
+    - rid: 2644742391991631949
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 2644742391991631939
+    - rid: 2644742391991631950
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -176,12 +176,12 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 2644742391991631940
+    - rid: 2644742391991631951
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 2644742391991631941
+    - rid: 2644742391991631952
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -191,14 +191,14 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 2644742391991631942
+    - rid: 2644742391991631953
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 2644742391991631943
+    - rid: 2644742391991631954
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1


### PR DESCRIPTION
## Summary
- Add `RegisterPlayerCursor` API to PlayerManager and use it when spawning player cursors
- Register PlayerCursor instances with PlayerManager on spawn
- Simplify cursor update loop by iterating over dictionary values directly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689771be22dc8320a262be6967e46849