### PR TITLE
Avoid null-coalescing with Unity objects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ AGENTS Instructions:
 * Comments in Unity code must be written in English.
 * Comments in Delphi code must be written in Russian.
 * Follow the existing coding style, including variable and constant naming.
+* Avoid using null-coalescing operators (`??` and `??=`) with `UnityEngine.Object`. Use explicit `== null` checks instead.
 
 ### Critical Guideline for Asynchronous Code in Unity
 

--- a/Assets/Scripts/PlayerCursor.cs
+++ b/Assets/Scripts/PlayerCursor.cs
@@ -37,7 +37,10 @@ public class PlayerCursor : NetworkBehaviour
 
     private void ApplyMaterial(int index)
     {
-        _meshRenderer ??= GetComponentInChildren<MeshRenderer>();
+        if (_meshRenderer == null)
+        {
+            _meshRenderer = GetComponentInChildren<MeshRenderer>();
+        }
 
         if (_meshRenderer == null)
         {

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -32,7 +32,17 @@ public class Unit : NetworkBehaviour, IPositionable, ISelectableProvider
     /// <summary>
     /// Provides access to the Selectable component associated with this unit.
     /// </summary>
-    public ISelectable Selectable => _selectable ??= GetComponent<Selectable>();
+    public ISelectable Selectable
+    {
+        get
+        {
+            if (_selectable == null)
+            {
+                _selectable = GetComponent<Selectable>();
+            }
+            return _selectable;
+        }
+    }
     #endregion ISelectableProvider
 
     [Networked] public PlayerRef PlayerOwner { get; private set; }
@@ -189,7 +199,10 @@ public class Unit : NetworkBehaviour, IPositionable, ISelectableProvider
     /// </summary>
     public void ApplyMaterial(int index)
     {
-        _meshRenderer ??= GetComponentInChildren<MeshRenderer>();
+        if (_meshRenderer == null)
+        {
+            _meshRenderer = GetComponentInChildren<MeshRenderer>();
+        }
 
         if (_meshRenderer == null)
         {


### PR DESCRIPTION
## Summary
- Replace null-coalescing assignments for cached Unity components with explicit null checks
- Expand AGENTS guidelines to forbid using `??` and `??=` with `UnityEngine.Object`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f2197bec83208864c3b6603df192