### PR TITLE
Refactor material application into utility helper

### DIFF
--- a/Assets/Scripts/MaterialApplier.cs
+++ b/Assets/Scripts/MaterialApplier.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using static Corris.Loggers.Logger;
+using static Corris.Loggers.LogUtils;
+
+/// <summary>
+/// Provides utility methods for applying materials to mesh renderers.
+/// </summary>
+public static class MaterialApplier
+{
+    /// <summary>
+    /// Applies a material to the given mesh renderer using the material index.
+    /// Logs errors or success messages using the provided entity name.
+    /// </summary>
+    /// <param name="renderer">The MeshRenderer to apply the material to.</param>
+    /// <param name="index">The material index used to retrieve the material.</param>
+    /// <param name="entityName">Name of the entity for logging purposes.</param>
+    /// <returns>True if the material was successfully applied, otherwise false.</returns>
+    public static bool ApplyMaterial(MeshRenderer renderer, int index, string entityName)
+    {
+        if (renderer == null)
+        {
+            LogError($"{GetLogCallPrefix(typeof(MaterialApplier))} MeshRenderer not found for {entityName} Index[{index}].");
+            return false;
+        }
+
+        var material = PlayerMaterialProvider.GetMaterial(index);
+
+        if (material == null)
+        {
+            LogError($"{GetLogCallPrefix(typeof(MaterialApplier))} Material not found for {entityName} Index[{index}].");
+            return false;
+        }
+
+        renderer.material = material;
+        Log($"{GetLogCallPrefix(typeof(MaterialApplier))} Material successfully loaded and applied to {entityName} Index[{index}].");
+        return true;
+    }
+}

--- a/Assets/Scripts/PlayerCursor.cs
+++ b/Assets/Scripts/PlayerCursor.cs
@@ -17,16 +17,31 @@ public class PlayerCursor : NetworkBehaviour
 
     private MeshRenderer _meshRenderer;
 
+    /// <summary>
+    /// Cached MeshRenderer component of the cursor.
+    /// </summary>
+    private MeshRenderer MeshRenderer
+    {
+        get
+        {
+            if (_meshRenderer == null)
+            {
+                _meshRenderer = GetComponentInChildren<MeshRenderer>();
+            }
+            return _meshRenderer;
+        }
+    }
+
     public override void Spawned()
     {
         base.Spawned();
         PlayerCursorRegistry.Register(Object.InputAuthority, this);
-        ApplyMaterial(MaterialIndex);
+        MaterialApplier.ApplyMaterial(MeshRenderer, MaterialIndex, "Cursor");
     }
 
     private void OnMaterialIndexChanged()
     {
-       ApplyMaterial(MaterialIndex);
+        MaterialApplier.ApplyMaterial(MeshRenderer, MaterialIndex, "Cursor");
     }
 
     public override void Despawned(NetworkRunner runner, bool hasState)
@@ -35,28 +50,4 @@ public class PlayerCursor : NetworkBehaviour
         base.Despawned(runner, hasState);
     }
 
-    private void ApplyMaterial(int index)
-    {
-        if (_meshRenderer == null)
-        {
-            _meshRenderer = GetComponentInChildren<MeshRenderer>();
-        }
-
-        if (_meshRenderer == null)
-        {
-            LogError($"{GetLogCallPrefix(GetType())} MeshRenderer not found for Cursor Index[{index}].");
-            return;
-        }
-
-        var material = PlayerMaterialProvider.GetMaterial(index);
-
-        if (material == null)
-        {
-            LogError($"{GetLogCallPrefix(GetType())} Material not found for Cursor Index[{index}].");
-            return;
-        }
-
-        _meshRenderer.material = material;
-        Log($"{GetLogCallPrefix(GetType())} Material successfully loaded and applied to Cursor Index[{index}].");
-    }
 }

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -296,7 +296,7 @@ public class PlayerManager : NetworkBehaviour
                 if (networkObject != null && networkObject.TryGetComponent<Unit>(out var unit))
                 {
                     unit.materialIndex = index;
-                    unit.ApplyMaterial(index);
+                    MaterialApplier.ApplyMaterial(unit.MeshRenderer, index, "Unit");
                 }
             }
         }

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -16,6 +16,21 @@ public class Unit : NetworkBehaviour, IPositionable, ISelectableProvider
     private MeshRenderer _meshRenderer; // Cache for MeshRenderer to avoid repeated lookups
 
     /// <summary>
+    /// Cached MeshRenderer component of the unit.
+    /// </summary>
+    public MeshRenderer MeshRenderer
+    {
+        get
+        {
+            if (_meshRenderer == null)
+            {
+                _meshRenderer = GetComponentInChildren<MeshRenderer>();
+            }
+            return _meshRenderer;
+        }
+    }
+
+    /// <summary>
     /// Material index, for passing to other clients via RPC
     /// </summary>
     public int materialIndex;
@@ -185,40 +200,12 @@ public class Unit : NetworkBehaviour, IPositionable, ISelectableProvider
             {
                 unit.name = unitName;
                 unit.materialIndex = materialIndex;
-                unit.ApplyMaterial(materialIndex);
+                MaterialApplier.ApplyMaterial(unit.MeshRenderer, materialIndex, "Unit");
             }
         }
         else
         {
             LogError($"{GetLogCallPrefix(GetType())} Failed to find the unit from unitId.");
         }
-    }
-
-    /// <summary>
-    /// Applies material to the unit using cached renderer.
-    /// </summary>
-    public void ApplyMaterial(int index)
-    {
-        if (_meshRenderer == null)
-        {
-            _meshRenderer = GetComponentInChildren<MeshRenderer>();
-        }
-
-        if (_meshRenderer == null)
-        {
-            LogError($"{GetLogCallPrefix(GetType())} MeshRenderer not found for Unit Index[{index}].");
-            return;
-        }
-
-        var material = PlayerMaterialProvider.GetMaterial(index);
-
-        if (material == null)
-        {
-            LogError($"{GetLogCallPrefix(GetType())} Material not found for Unit Index[{index}].");
-            return;
-        }
-
-        _meshRenderer.material = material;
-        Log($"{GetLogCallPrefix(GetType())} Material successfully loaded and applied to Unit Index[{index}].");
     }
 }


### PR DESCRIPTION
## Summary
- centralize material assignment with new `MaterialApplier` utility
- use `MaterialApplier` in `PlayerCursor`, `Unit`, and `PlayerManager` with cached renderers

## Testing
- `mcs Assets/Scripts/*.cs` *(fails: Feature `default literal' cannot be used because it is not part of the C# 7.0 language specification, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6899f770278083208c0a20743e217160