### PR TITLE
Use dynamic array for unit RPC list

### DIFF
--- a/Assets/Scripts/NetworkInputData.cs
+++ b/Assets/Scripts/NetworkInputData.cs
@@ -1,37 +1,14 @@
 using Fusion;
-using System;
-using System.Collections.Generic;
-using Unity.Collections;
 using UnityEngine;
-using System.Collections;
 
+/// <summary>
+/// Network input payload sent every simulation tick.
+/// Currently holds only the player’s mouse position in world space so other clients can visualize it.
+/// </summary>
 public struct NetworkInputData : INetworkInput
 {
     // The mouse world position is used to show opponent's mouse position in the game world.
     public Vector3 mouseWorldPosition;
-}
-
-public struct UnitIdList : INetworkStruct
-{
-    public const int MaxUnits = 50;
-    unsafe fixed uint _unitIds[MaxUnits];
-    public int Length => MaxUnits;
-
-
-    public uint this[int index]
-    {
-        get { unsafe { return _unitIds[index]; } }
-        set { unsafe { _unitIds[index] = value; } }
-    }
-
-    public void Clear()
-    {
-        unsafe
-        {
-            for (int i = 0; i < MaxUnits; i++)
-                _unitIds[i] = 0;
-        }
-    }
 }
 
 


### PR DESCRIPTION
## Summary
- document NetworkInputData payload
- drop fixed-size UnitIdList and send unit IDs as dynamic array

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689a1aa01a208320a60faafe8ea4ce68