### PR TITLE
Clear registries on shutdown and scene load

### DIFF
--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -166,8 +166,14 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks
         StartGameAsync(mode);
     }
 
+    private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        UnitRegistry.Clear();
+        PlayerCursorRegistry.Clear();
+    }
 
     // --- INetworkRunnerCallbacks Implementation ---
+    #region INetworkRunnerCallbacks Implementation
 
     public void OnInput(NetworkRunner runner, NetworkInput input)
     {
@@ -204,8 +210,16 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks
         PlayerCursorRegistry.Clear();
         OnDisconnected?.Invoke();
     }
+    public void OnSceneLoadStart(NetworkRunner runner)
+    {
+        Log($"{GetLogCallPrefix(GetType())} OnSceneLoadStart triggered");
+        UnitRegistry.Clear();
+        PlayerCursorRegistry.Clear();
+    }
 
-    #region INetworkRunnerCallbacks Implementation
+    #region INetworkRunnerCallbacks Implementation Unassigned
+
+
     public void OnInputMissing(NetworkRunner runner, PlayerRef player, NetworkInput input) { Log($"{GetLogCallPrefix(GetType())} OnInputMissing triggered"); }
     public void OnConnectedToServer(NetworkRunner runner) { Log($"{GetLogCallPrefix(GetType())} OnConnectedToServer triggered"); }
     public void OnDisconnectedFromServer(NetworkRunner runner, NetDisconnectReason reason) { Log($"{GetLogCallPrefix(GetType())} OnDisconnectedFromServer triggered"); }
@@ -215,22 +229,12 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks
     public void OnSessionListUpdated(NetworkRunner runner, List<SessionInfo> sessionList) { Log($"{GetLogCallPrefix(GetType())} OnSessionListUpdated triggered"); }
     public void OnCustomAuthenticationResponse(NetworkRunner runner, Dictionary<string, object> data) { Log($"{GetLogCallPrefix(GetType())} OnCustomAuthenticationResponse triggered"); }
     public void OnHostMigration(NetworkRunner runner, HostMigrationToken hostMigrationToken) { Log($"{GetLogCallPrefix(GetType())} OnHostMigration triggered"); }
-    public void OnSceneLoadStart(NetworkRunner runner)
-    {
-        Log($"{GetLogCallPrefix(GetType())} OnSceneLoadStart triggered");
-        UnitRegistry.Clear();
-        PlayerCursorRegistry.Clear();
-    }
-
-    private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
-    {
-        UnitRegistry.Clear();
-        PlayerCursorRegistry.Clear();
-    }
     public void OnObjectExitAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { Log($"{GetLogCallPrefix(GetType())} OnObjectExitAOI triggered"); }
     public void OnObjectEnterAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { Log($"{GetLogCallPrefix(GetType())} OnObjectEnterAOI triggered"); }
     public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ReliableKey key, ArraySegment<byte> data) { Log($"{GetLogCallPrefix(GetType())} OnReliableDataReceived triggered"); }
     public void OnReliableDataProgress(NetworkRunner runner, PlayerRef player, ReliableKey key, float progress) { Log($"{GetLogCallPrefix(GetType())} OnReliableDataProgress triggered"); }
+    #endregion INetworkRunnerCallbacks Implementation Unassigned
+
     #endregion
 
 }

--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -65,6 +65,16 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks
         Log($"{GetLogCallPrefix(GetType())} ConnectionManager Instance!");
     }
 
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += HandleSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= HandleSceneLoaded;
+    }
+
     private void OnDestroy()
     {
         // Cleanup singleton instance
@@ -190,6 +200,8 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks
     public void OnShutdown(NetworkRunner runner, ShutdownReason shutdownReason)
     {
         Log($"{GetLogCallPrefix(GetType())} OnShutdown triggered with reason: {shutdownReason}");
+        UnitRegistry.Clear();
+        PlayerCursorRegistry.Clear();
         OnDisconnected?.Invoke();
     }
 
@@ -203,7 +215,18 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks
     public void OnSessionListUpdated(NetworkRunner runner, List<SessionInfo> sessionList) { Log($"{GetLogCallPrefix(GetType())} OnSessionListUpdated triggered"); }
     public void OnCustomAuthenticationResponse(NetworkRunner runner, Dictionary<string, object> data) { Log($"{GetLogCallPrefix(GetType())} OnCustomAuthenticationResponse triggered"); }
     public void OnHostMigration(NetworkRunner runner, HostMigrationToken hostMigrationToken) { Log($"{GetLogCallPrefix(GetType())} OnHostMigration triggered"); }
-    public void OnSceneLoadStart(NetworkRunner runner) { Log($"{GetLogCallPrefix(GetType())} OnSceneLoadStart triggered"); }
+    public void OnSceneLoadStart(NetworkRunner runner)
+    {
+        Log($"{GetLogCallPrefix(GetType())} OnSceneLoadStart triggered");
+        UnitRegistry.Clear();
+        PlayerCursorRegistry.Clear();
+    }
+
+    private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        UnitRegistry.Clear();
+        PlayerCursorRegistry.Clear();
+    }
     public void OnObjectExitAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { Log($"{GetLogCallPrefix(GetType())} OnObjectExitAOI triggered"); }
     public void OnObjectEnterAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { Log($"{GetLogCallPrefix(GetType())} OnObjectEnterAOI triggered"); }
     public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ReliableKey key, ArraySegment<byte> data) { Log($"{GetLogCallPrefix(GetType())} OnReliableDataReceived triggered"); }

--- a/Assets/Scripts/PlayerCursorRegistry.cs
+++ b/Assets/Scripts/PlayerCursorRegistry.cs
@@ -29,6 +29,14 @@ public static class PlayerCursorRegistry
     }
 
     /// <summary>
+    /// Clears the registry of all player cursors.
+    /// </summary>
+    public static void Clear()
+    {
+        Cursors.Clear();
+    }
+
+    /// <summary>
     /// Attempts to get the cursor for the specified player.
     /// </summary>
     public static bool TryGet(PlayerRef player, out PlayerCursor cursor)

--- a/Assets/Scripts/UnitRegistry.cs
+++ b/Assets/Scripts/UnitRegistry.cs
@@ -12,4 +12,12 @@ public static class UnitRegistry
     /// The dictionary holding all active units. Key is the unit's raw NetworkId (uint), Value is the unit reference.
     /// </summary>
     public static readonly Dictionary<uint, Unit> Units = new();
+
+    /// <summary>
+    /// Clears the registry of all units.
+    /// </summary>
+    public static void Clear()
+    {
+        Units.Clear();
+    }
 }


### PR DESCRIPTION
## Summary
- add `Clear` utility to `UnitRegistry` and `PlayerCursorRegistry`
- clear registries on shutdown and when scenes load

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689afde595d483209a88154157b10ddf