### PR TITLE
Use ScriptableObject for player materials

### DIFF
--- a/Assets/Resources/PlayerMaterialList.asset
+++ b/Assets/Resources/PlayerMaterialList.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 941a7687b63b40efa28951a84babecca, type: 3}
+  m_Name: PlayerMaterialList
+  m_EditorClassIdentifier:
+  _materials:
+  - {fileID: 2100000, guid: 49743f17233b35a428a49bfbd6aaebe7, type: 2}
+  - {fileID: 2100000, guid: f41db636c8d285b4d9064d4b83e6ce5c, type: 2}
+  - {fileID: 2100000, guid: 74d615d6e30169846bb363dca82c36de, type: 2}
+  - {fileID: 2100000, guid: a9151bda23c8e3248889c6d123f360f1, type: 2}

--- a/Assets/Resources/PlayerMaterialList.asset.meta
+++ b/Assets/Resources/PlayerMaterialList.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4ef7b50f3f04675b23f28f84e291aca
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerMaterialList.cs
+++ b/Assets/Scripts/PlayerMaterialList.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Holds a list of player materials configurable from the inspector.
+/// </summary>
+[CreateAssetMenu(fileName = "PlayerMaterialList", menuName = "Config/Player Material List")]
+public class PlayerMaterialList : ScriptableObject
+{
+    [SerializeField] private List<Material> _materials = new();
+
+    /// <summary>
+    /// List of materials available for players.
+    /// </summary>
+    public IReadOnlyList<Material> Materials => _materials;
+}

--- a/Assets/Scripts/PlayerMaterialList.cs.meta
+++ b/Assets/Scripts/PlayerMaterialList.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 941a7687b63b40efa28951a84babecca

--- a/Assets/Scripts/PlayerMaterialProvider.cs
+++ b/Assets/Scripts/PlayerMaterialProvider.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 public static class PlayerMaterialProvider
 {
     private static readonly Dictionary<int, Material> _materials = new();
+    private static PlayerMaterialList _materialList;
 
     /// <summary>
     /// Returns a material for the given index. The material is loaded once and then cached.
@@ -18,8 +19,21 @@ public static class PlayerMaterialProvider
             return material;
         }
 
-        string materialName = $"Materials/UnitPlayer{index}_Material";
-        material = Resources.Load<Material>(materialName);
+        if (_materialList == null)
+        {
+            _materialList = Resources.Load<PlayerMaterialList>("PlayerMaterialList");
+            if (_materialList == null)
+            {
+                return null;
+            }
+        }
+
+        if (index < 0 || index >= _materialList.Materials.Count)
+        {
+            return null;
+        }
+
+        material = _materialList.Materials[index];
         if (material != null)
         {
             _materials[index] = material;


### PR DESCRIPTION
## Summary
- add `PlayerMaterialList` ScriptableObject for configurable material list
- load materials from `PlayerMaterialList` instead of string paths
- provide sample `PlayerMaterialList` asset with existing materials

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689afdb5d4b083209ac3d86b3ba7da6f