### PR TITLE
Refactor connection startup to return Task

### DIFF
--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -135,7 +135,7 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks
 
     }
 
-    private async void StartGameAsync(GameMode mode)
+    private async Task StartGameAsync(GameMode mode)
     {
         // Prevent multiple concurrent calls.
         if (_isConnecting) return;
@@ -154,16 +154,21 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks
                 OnDisconnected?.Invoke();
             }
         }
+        catch (Exception ex)
+        {
+            LogError($"{GetLogCallPrefix(GetType())} StartGameAsync exception: {ex.Message}");
+            throw;
+        }
         finally
         {
             _isConnecting = false;
         }
     }
 
-    public void StartGamePublic(GameMode mode)
+    public Task StartGamePublic(GameMode mode)
     {
         // Public wrapper to be called from UI scripts.
-        StartGameAsync(mode);
+        return StartGameAsync(mode);
     }
 
     private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)

--- a/Assets/Scripts/GameLauncher.cs
+++ b/Assets/Scripts/GameLauncher.cs
@@ -60,8 +60,8 @@ public class GameLauncher : MonoBehaviour
 
         _buttons = new[] { _hostButton, _joinButton, _exitButton };
 
-        _hostButton.onClick.AddListener(() => _connectionManager.StartGamePublic(GameMode.Host));
-        _joinButton.onClick.AddListener(() => _connectionManager.StartGamePublic(GameMode.Client));
+        _hostButton.onClick.AddListener(async () => await _connectionManager.StartGamePublic(GameMode.Host));
+        _joinButton.onClick.AddListener(async () => await _connectionManager.StartGamePublic(GameMode.Client));
         _exitButton.onClick.AddListener(QuitGame);
     }
 


### PR DESCRIPTION
## Summary
- Refactor connection startup functions to return `Task` and surface errors
- Await connection startup calls from `GameLauncher`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b3c4491948320b96c440f6841d17d