### PR TITLE
Introduce INetworkEvents for network callbacks and update PlayerManager

### DIFF
--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -29,7 +29,7 @@ public delegate void OnInputHandler(ref NetworkInputData data);
 /// <summary>
 /// Exposes connection functionality through <see cref="IConnectionService"/> to allow dependency injection.
 /// </summary>
-public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnectionService
+public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnectionService, INetworkEvents
 {
     // --- Public Events ---
     public static event Action OnConnectingStarted; // Temporary for legacy access
@@ -40,9 +40,9 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
     public event Action Connected;
     public event Action Disconnected;
 
-    public static event Action<NetworkRunner, PlayerRef> On_PlayerJoined;
-    public static event Action<NetworkRunner, PlayerRef> On_PlayerLeft;
-    public static event OnInputHandler On_Input;
+    public event Action<NetworkRunner, PlayerRef> PlayerJoined;
+    public event Action<NetworkRunner, PlayerRef> PlayerLeft;
+    public event OnInputHandler Input;
 
     // Singleton Instance
     public static ConnectionManager Instance { get; private set; }
@@ -194,7 +194,7 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
     {
         NetworkInputData data = default;
 
-        On_Input?.Invoke(ref data);   
+        Input?.Invoke(ref data);
 
         input.Set(data);
     }
@@ -203,14 +203,14 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
     {
         Log($"{GetLogCallPrefix(GetType())} Player joined: {player}");
 
-        On_PlayerJoined?.Invoke(runner, player);
+        PlayerJoined?.Invoke(runner, player);
     }
 
     public void OnPlayerLeft(NetworkRunner runner, PlayerRef player)
     {
         Log($"{GetLogCallPrefix(GetType())} Player left: {player}");
 
-        On_PlayerLeft?.Invoke(runner, player);
+        PlayerLeft?.Invoke(runner, player);
     }
 
     public void OnSceneLoadDone(NetworkRunner runner)

--- a/Assets/Scripts/INetworkEvents.cs
+++ b/Assets/Scripts/INetworkEvents.cs
@@ -1,0 +1,23 @@
+using System;
+using Fusion;
+
+/// <summary>
+/// Exposes network-related events for player connections and input handling.
+/// </summary>
+public interface INetworkEvents
+{
+    /// <summary>
+    /// Triggered when a player joins the session.
+    /// </summary>
+    event Action<NetworkRunner, PlayerRef> PlayerJoined;
+
+    /// <summary>
+    /// Triggered when a player leaves the session.
+    /// </summary>
+    event Action<NetworkRunner, PlayerRef> PlayerLeft;
+
+    /// <summary>
+    /// Triggered to collect input data for the network simulation.
+    /// </summary>
+    event OnInputHandler Input;
+}

--- a/Assets/Scripts/INetworkEvents.cs.meta
+++ b/Assets/Scripts/INetworkEvents.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 993d249b874a8d8409b85dc1132a77b7

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -13,7 +13,7 @@ using VContainer;
 /// </summary>
 public class PlayerManager : NetworkBehaviour
 {
-    NetworkRunner NetRunner => _connectionService?.Runner;
+    NetworkRunner NetRunner => _connectionService != null ? _connectionService.Runner : null;
 
     // --- Dependencies ---
     [Header("Dependencies")]

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using static Corris.Loggers.Logger;
 using static Corris.Loggers.LogUtils;
+using VContainer;
 
 /// <summary>
 /// Handles game logic related to players, such as spawning units when a player joins,
@@ -12,7 +13,7 @@ using static Corris.Loggers.LogUtils;
 /// </summary>
 public class PlayerManager : NetworkBehaviour
 {
-    NetworkRunner NetRunner => ConnectionManager.Instance.NetRunner;
+    NetworkRunner NetRunner => _connectionService?.Runner;
 
     // --- Dependencies ---
     [Header("Dependencies")]
@@ -44,23 +45,52 @@ public class PlayerManager : NetworkBehaviour
     // Counter to assign a unique material index to each new player.
     private int _spawnedPlayersCount = 0;
 
+    // --- Dependencies ---
+    private IConnectionService _connectionService;
+    private INetworkEvents _networkEvents;
+
+    [Inject]
+    public void Construct(IConnectionService connectionService, INetworkEvents networkEvents)
+    {
+        Log($"{GetLogCallPrefix(GetType())} VContainer Inject!");
+        _connectionService = connectionService;
+        _networkEvents = networkEvents;
+    }
+
     // --- Unity & Event Subscription ---
     private void OnEnable()
     {
         InputManager.OnSecondaryMouseClick_World += HandleMoveCommand;
         InputManager.OnMouseMove += CacheMousePosition;
-        ConnectionManager.On_PlayerJoined += HandlePlayerJoined;
-        ConnectionManager.On_PlayerLeft += HandlePlayerLeft;
-        ConnectionManager.On_Input += TryGetNetworkInput;
+    }
+
+    private void Start()
+    {
+        if (_connectionService == null)
+        {
+            LogError($"{GetLogCallPrefix(GetType())} Connection service NIL!");
+        }
+        if (_networkEvents == null)
+        {
+            LogError($"{GetLogCallPrefix(GetType())} Network events NIL!");
+            return;
+        }
+
+        _networkEvents.PlayerJoined += HandlePlayerJoined;
+        _networkEvents.PlayerLeft += HandlePlayerLeft;
+        _networkEvents.Input += TryGetNetworkInput;
     }
 
     private void OnDisable()
     {
         InputManager.OnSecondaryMouseClick_World -= HandleMoveCommand;
         InputManager.OnMouseMove -= CacheMousePosition;
-        ConnectionManager.On_PlayerLeft -= HandlePlayerLeft;
-        ConnectionManager.On_PlayerJoined -= HandlePlayerJoined;
-        ConnectionManager.On_Input -= TryGetNetworkInput;
+        if (_networkEvents != null)
+        {
+            _networkEvents.PlayerLeft -= HandlePlayerLeft;
+            _networkEvents.PlayerJoined -= HandlePlayerJoined;
+            _networkEvents.Input -= TryGetNetworkInput;
+        }
     }
 
     public override void FixedUpdateNetwork()

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -62,14 +62,7 @@ public class PlayerManager : NetworkBehaviour
     {
         InputManager.OnSecondaryMouseClick_World += HandleMoveCommand;
         InputManager.OnMouseMove += CacheMousePosition;
-    }
 
-    private void Start()
-    {
-        if (_connectionService == null)
-        {
-            LogError($"{GetLogCallPrefix(GetType())} Connection service NIL!");
-        }
         if (_networkEvents == null)
         {
             LogError($"{GetLogCallPrefix(GetType())} Network events NIL!");
@@ -79,6 +72,14 @@ public class PlayerManager : NetworkBehaviour
         _networkEvents.PlayerJoined += HandlePlayerJoined;
         _networkEvents.PlayerLeft += HandlePlayerLeft;
         _networkEvents.Input += TryGetNetworkInput;
+    }
+
+    private void Start()
+    {
+        if (_connectionService == null)
+        {
+            LogError($"{GetLogCallPrefix(GetType())} Connection service NIL!");
+        }
     }
 
     private void OnDisable()

--- a/Assets/Scripts/ProjectLifetimeScope.cs
+++ b/Assets/Scripts/ProjectLifetimeScope.cs
@@ -15,6 +15,7 @@ public class ProjectLifetimeScope : LifetimeScope
 
         builder.RegisterComponentInHierarchy<ConnectionManager>()
             .As<IConnectionService>()
+            .As<INetworkEvents>()
             .AsSelf();
         // Note: RegisterComponentInHierarchy already registers as Singleton by default in VContainer.
         // The .WithLifetime(Lifetime.Singleton) call is not needed and causes CS1061.
@@ -22,5 +23,6 @@ public class ProjectLifetimeScope : LifetimeScope
         builder.RegisterComponentInHierarchy<GameLauncher>();
         builder.RegisterComponentInHierarchy<Panel_Status>();
         builder.RegisterComponentInHierarchy<SelectionManager>();
+        builder.RegisterComponentInHierarchy<PlayerManager>();
     }
 }

--- a/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -33,24 +33,24 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 2644742481113251901
-      - rid: 2644742481113251902
+      - rid: 2644742481113251912
+      - rid: 2644742481113251913
       - rid: 6852985685364965378
       - rid: 6852985685364965379
       - rid: 6852985685364965380
       - rid: 6852985685364965381
-      - rid: 2644742481113251903
-      - rid: 2644742481113251904
+      - rid: 2644742481113251914
+      - rid: 2644742481113251915
       - rid: 6852985685364965384
       - rid: 6852985685364965385
-      - rid: 2644742481113251905
-      - rid: 2644742481113251906
-      - rid: 2644742481113251907
-      - rid: 2644742481113251908
-      - rid: 2644742481113251909
-      - rid: 2644742481113251910
+      - rid: 2644742481113251916
+      - rid: 2644742481113251917
+      - rid: 2644742481113251918
+      - rid: 2644742481113251919
+      - rid: 2644742481113251920
+      - rid: 2644742481113251921
       - rid: 6852985685364965392
-      - rid: 2644742481113251911
+      - rid: 2644742481113251922
       - rid: 6852985685364965394
       - rid: 8712630790384254976
       - rid: 196572100355162112
@@ -102,14 +102,14 @@ MonoBehaviour:
         m_xrOcclusionMeshPS: {fileID: 4800000, guid: 4431b1f1f743fbf4eb310a967890cbea, type: 3}
         m_xrMirrorViewPS: {fileID: 4800000, guid: d5a307c014552314b9f560906d708772, type: 3}
         m_xrMotionVector: {fileID: 4800000, guid: f89aac1e4f84468418fe30e611dff395, type: 3}
-    - rid: 2644742481113251901
+    - rid: 2644742481113251912
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 1
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 2644742481113251902
+    - rid: 2644742481113251913
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -121,7 +121,7 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 2644742481113251903
+    - rid: 2644742481113251914
       type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -136,7 +136,7 @@ MonoBehaviour:
         m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
         m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
         m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 2644742481113251904
+    - rid: 2644742481113251915
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -144,7 +144,7 @@ MonoBehaviour:
         m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
-    - rid: 2644742481113251905
+    - rid: 2644742481113251916
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -157,13 +157,13 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 2644742481113251906
+    - rid: 2644742481113251917
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 2644742481113251907
+    - rid: 2644742481113251918
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -176,12 +176,12 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 2644742481113251908
+    - rid: 2644742481113251919
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 2644742481113251909
+    - rid: 2644742481113251920
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -191,14 +191,14 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 2644742481113251910
+    - rid: 2644742481113251921
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 2644742481113251911
+    - rid: 2644742481113251922
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1

--- a/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -33,24 +33,24 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 2644742458610286686
-      - rid: 2644742458610286687
+      - rid: 2644742481113251901
+      - rid: 2644742481113251902
       - rid: 6852985685364965378
       - rid: 6852985685364965379
       - rid: 6852985685364965380
       - rid: 6852985685364965381
-      - rid: 2644742458610286688
-      - rid: 2644742458610286689
+      - rid: 2644742481113251903
+      - rid: 2644742481113251904
       - rid: 6852985685364965384
       - rid: 6852985685364965385
-      - rid: 2644742458610286690
-      - rid: 2644742458610286691
-      - rid: 2644742458610286692
-      - rid: 2644742458610286693
-      - rid: 2644742458610286694
-      - rid: 2644742458610286695
+      - rid: 2644742481113251905
+      - rid: 2644742481113251906
+      - rid: 2644742481113251907
+      - rid: 2644742481113251908
+      - rid: 2644742481113251909
+      - rid: 2644742481113251910
       - rid: 6852985685364965392
-      - rid: 2644742458610286696
+      - rid: 2644742481113251911
       - rid: 6852985685364965394
       - rid: 8712630790384254976
       - rid: 196572100355162112
@@ -102,14 +102,14 @@ MonoBehaviour:
         m_xrOcclusionMeshPS: {fileID: 4800000, guid: 4431b1f1f743fbf4eb310a967890cbea, type: 3}
         m_xrMirrorViewPS: {fileID: 4800000, guid: d5a307c014552314b9f560906d708772, type: 3}
         m_xrMotionVector: {fileID: 4800000, guid: f89aac1e4f84468418fe30e611dff395, type: 3}
-    - rid: 2644742458610286686
+    - rid: 2644742481113251901
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 1
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 2644742458610286687
+    - rid: 2644742481113251902
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -121,7 +121,7 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 2644742458610286688
+    - rid: 2644742481113251903
       type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -136,7 +136,7 @@ MonoBehaviour:
         m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
         m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
         m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 2644742458610286689
+    - rid: 2644742481113251904
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -144,7 +144,7 @@ MonoBehaviour:
         m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
-    - rid: 2644742458610286690
+    - rid: 2644742481113251905
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -157,13 +157,13 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 2644742458610286691
+    - rid: 2644742481113251906
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 2644742458610286692
+    - rid: 2644742481113251907
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -176,12 +176,12 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 2644742458610286693
+    - rid: 2644742481113251908
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 2644742458610286694
+    - rid: 2644742481113251909
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -191,14 +191,14 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 2644742458610286695
+    - rid: 2644742481113251910
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 2644742458610286696
+    - rid: 2644742481113251911
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1


### PR DESCRIPTION
## Summary
- Define `INetworkEvents` to expose player connection and input events
- Implement `INetworkEvents` in `ConnectionManager` and register with VContainer
- Inject `INetworkEvents` into `PlayerManager` and replace static event usage

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689c86a4c21c8320ab210643ca6f04e2