### PR TITLE
Refactor unit offset configuration

### DIFF
--- a/Assets/Resources/GameSettings.asset
+++ b/Assets/Resources/GameSettings.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 930b372d5fb749828d96caa55a621dcf, type: 3}
+  m_Name: GameSettings
+  m_EditorClassIdentifier:
+  unitAllowedOffset: 1

--- a/Assets/Resources/GameSettings.asset.meta
+++ b/Assets/Resources/GameSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59b9238a41f244fb8096ce8407409de1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/GameSettings.cs
+++ b/Assets/Scripts/GameSettings.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+/// <summary>
+/// Global game configuration settings.
+/// </summary>
+[CreateAssetMenu(fileName = "GameSettings", menuName = "Config/Game Settings")]
+public class GameSettings : ScriptableObject
+{
+    /// <summary>
+    /// The maximum allowed offset for a unit from the center of the group.
+    /// </summary>
+    public int unitAllowedOffset = 1;
+}

--- a/Assets/Scripts/GameSettings.cs.meta
+++ b/Assets/Scripts/GameSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 930b372d5fb749828d96caa55a621dcf

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -97,14 +97,23 @@ public class Unit : NetworkBehaviour, IPositionable, ISelectableProvider
     }
 
     /// <summary>
-    /// Function finds unitTargetPosition, taking into account the offset of itself relative to the center of the group of units
+    /// Limits the offset magnitude so that the units are not too far apart.
     /// </summary>
-    public Vector3 GetUnitTargetPosition(Vector3 center, Vector3 bearingTargetPosition)
+    /// <param name="offset">Original offset from the group center.</param>
+    /// <param name="allowedOffset">Maximum allowed distance.</param>
+    public Vector3 ClampOffset(Vector3 offset, float allowedOffset)
     {
-        Vector3 offset = center - transform.position;
-        // here you can limit the offset so that the units are not too far apart
-        offset = Vector3.ClampMagnitude(offset, ConnectionManager.Instance.PlayerManager.unitAllowedOffset); // limit the offset to 5 meters
-                                                                                          // find the personal position for the Target of this unit, taking into account that it is offset relative to the center of the selected units
+        // limit the offset to the allowed distance
+        return Vector3.ClampMagnitude(offset, allowedOffset);
+    }
+
+    /// <summary>
+    /// Finds the personal target position for this unit, taking into account that it is offset relative to the center of the selected units.
+    /// </summary>
+    /// <param name="offset">Offset relative to the group center.</param>
+    /// <param name="bearingTargetPosition">Desired position for the group's center.</param>
+    public Vector3 GetUnitTargetPosition(Vector3 offset, Vector3 bearingTargetPosition)
+    {
         Vector3 unitTargetPosition = bearingTargetPosition - offset;
         return unitTargetPosition;
     }


### PR DESCRIPTION
## Summary
- Remove direct ConnectionManager dependency from Unit offset calculation
- Read unit offset limit from GameSettings ScriptableObject
- Use PlayerManager to clamp unit offsets when issuing move commands
- Assign GameSettings through a serialized field instead of Resources.Load

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c9bb4fadc8320a4aa673a77057da5