### PR TITLE
Use UnityObjectExtensions for interface null checks

### DIFF
--- a/Assets/Scripts/GameLauncher.cs
+++ b/Assets/Scripts/GameLauncher.cs
@@ -43,7 +43,7 @@ public class GameLauncher : MonoBehaviour
 
     private void Start()
     {
-        if (_connectionService == null)
+        if (_connectionService.IsNullOrDestroyed())
         {
             LogError($"{GetLogCallPrefix(GetType())} Connection service NIL!");
             enabled = false;
@@ -108,11 +108,11 @@ public class GameLauncher : MonoBehaviour
 
     private void Update()
     {
-        if (_connectionService == null)
+        if (_connectionService.IsNullOrDestroyed())
             return;
 
         bool selectionActive = SelectionManager.IsSelecting;
-        bool runnerMissing = _connectionService.Runner == null;
+        bool runnerMissing = _connectionService.Runner.IsNullOrDestroyed();
 
         _hostButton.gameObject.SetActive(runnerMissing);
         _joinButton.gameObject.SetActive(runnerMissing);

--- a/Assets/Scripts/Panel_Status.cs
+++ b/Assets/Scripts/Panel_Status.cs
@@ -43,7 +43,7 @@ public class Panel_Status : MonoBehaviour
     private void OnDestroy()
     {
         // Unsubscribe from connection events
-        if (_connectionService != null)
+        if (!_connectionService.IsNullOrDestroyed())
         {
             _connectionService.ConnectingStarted -= StartConnecting;
             _connectionService.Connected -= SetConnected;
@@ -53,7 +53,7 @@ public class Panel_Status : MonoBehaviour
 
     private void Start()
     {
-        if (_connectionService == null)
+        if (_connectionService.IsNullOrDestroyed())
         {
             LogError($"{GetLogCallPrefix(GetType())} Connection service NIL!");
         }

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -13,7 +13,7 @@ using VContainer;
 /// </summary>
 public class PlayerManager : NetworkBehaviour
 {
-    NetworkRunner NetRunner => _connectionService != null ? _connectionService.Runner : null;
+    NetworkRunner NetRunner => !_connectionService.IsNullOrDestroyed() ? _connectionService.Runner : null;
 
     // --- Dependencies ---
     [Header("Dependencies")]
@@ -74,13 +74,13 @@ public class PlayerManager : NetworkBehaviour
     // --- Unity & Event Subscription ---
     private void OnEnable()
     {
-        if (_inputService as UnityEngine.Object != null)
+        if (!_inputService.IsNullOrDestroyed())
         {
             _inputService.OnSecondaryMouseClick_World += HandleMoveCommand;
             _inputService.OnMouseMove += CacheMousePosition;
         }
 
-        if (_networkEvents as UnityEngine.Object == null)
+        if (_networkEvents.IsNullOrDestroyed())
         {
             LogError($"{GetLogCallPrefix(GetType())} Network events NIL!");
             return;
@@ -93,11 +93,11 @@ public class PlayerManager : NetworkBehaviour
 
     private void Start()
     {
-        if (_connectionService as UnityEngine.Object == null)
+        if (_connectionService.IsNullOrDestroyed())
         {
             LogError($"{GetLogCallPrefix(GetType())} Connection service NIL!");
         }
-        if (_inputService as UnityEngine.Object == null)
+        if (_inputService.IsNullOrDestroyed())
         {
             LogError($"{GetLogCallPrefix(GetType())} Input service NIL!");
         }
@@ -105,12 +105,12 @@ public class PlayerManager : NetworkBehaviour
 
     private void OnDisable()
     {
-        if (_inputService as UnityEngine.Object != null)
+        if (!_inputService.IsNullOrDestroyed())
         {
             _inputService.OnSecondaryMouseClick_World -= HandleMoveCommand;
             _inputService.OnMouseMove -= CacheMousePosition;
         }
-        if (_networkEvents != null)
+        if (!_networkEvents.IsNullOrDestroyed())
         {
             _networkEvents.PlayerLeft -= HandlePlayerLeft;
             _networkEvents.PlayerJoined -= HandlePlayerJoined;

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -41,11 +41,11 @@ public class SelectionManager : MonoBehaviour
 
     public void Start()
     {
-        if (_connectionService as UnityEngine.Object == null)
+        if (_connectionService.IsNullOrDestroyed())
         {
             LogError($"{GetLogCallPrefix(GetType())} Connection service NIL!");
         }
-        if (_inputService as UnityEngine.Object == null)
+        if (_inputService.IsNullOrDestroyed())
         {
             LogError($"{GetLogCallPrefix(GetType())} Input service NIL!");
         }
@@ -55,7 +55,7 @@ public class SelectionManager : MonoBehaviour
     public void OnEnable()
     {
         // Subscribe to input events
-        if (_inputService as UnityEngine.Object != null)
+        if (!_inputService.IsNullOrDestroyed())
         {
             _inputService.OnPrimaryMouseDown += StartSelection;
             _inputService.OnPrimaryMouseDrag += UpdateSelection;
@@ -66,7 +66,7 @@ public class SelectionManager : MonoBehaviour
     public void OnDisable()
     {
         // Unsubscribe from input events
-        if (_inputService as UnityEngine.Object != null)
+        if (!_inputService.IsNullOrDestroyed())
         {
             _inputService.OnPrimaryMouseDown -= StartSelection;
             _inputService.OnPrimaryMouseDrag -= UpdateSelection;
@@ -123,7 +123,7 @@ public class SelectionManager : MonoBehaviour
 
     private void SelectUnits()
     {
-        if (_connectionService.Runner == null)
+        if (_connectionService.Runner.IsNullOrDestroyed())
         {
             LogError($"{GetLogCallPrefix(GetType())} NetRunner is null. Cannot select units.");
             return;

--- a/Assets/Scripts/UnityObjectExtensions.cs
+++ b/Assets/Scripts/UnityObjectExtensions.cs
@@ -1,7 +1,14 @@
-// A helper to correctly check for null on any object that might be a Unity Object.
+/// <summary>
+/// Provides helpers to correctly check for null on any object that might be a Unity object.
+/// </summary>
 public static class UnityObjectExtensions
 {
-    // This generic extension method can be called on any interface or class.
+    /// <summary>
+    /// Determines whether the specified object is null or a destroyed <see cref="UnityEngine.Object"/>.
+    /// This generic extension method can be called on any interface or class.
+    /// </summary>
+    /// <param name="obj">The object to check.</param>
+    /// <returns><c>true</c> if the object is null or destroyed; otherwise, <c>false</c>.</returns>
     public static bool IsNullOrDestroyed(this object obj)
     {
         // If the object is a UnityEngine.Object, use the overloaded '==' operator.


### PR DESCRIPTION
## Summary
- replace direct null checks on injected interface dependencies with `IsNullOrDestroyed`
- document `UnityObjectExtensions` and `IsNullOrDestroyed`

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689daa2459d08320a4c49463a6e3d848