### PR TITLE
refactor: replace static registries with DI

### DIFF
--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -11,6 +11,8 @@ using static Corris.Loggers.Logger;
 using static Corris.Loggers.LogUtils;
 using UnityEngine.Windows;
 using VContainer;
+using VContainer.Unity;
+
 
 #if UNITY_EDITOR
 using UnityEditor;

--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -10,6 +10,7 @@ using UnityEngine.SceneManagement;
 using static Corris.Loggers.Logger;
 using static Corris.Loggers.LogUtils;
 using UnityEngine.Windows;
+using VContainer;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -53,6 +54,9 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
     // Prevent multiple connection attempts
     private bool _isConnecting = false;
     public bool IsConnecting => _isConnecting;
+
+    private IUnitRegistry _unitRegistry;
+    private IPlayerCursorRegistry _playerCursorRegistry;
 
     private void Awake()
     {
@@ -172,8 +176,8 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
 
     private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
     {
-        UnitRegistry.Clear();
-        PlayerCursorRegistry.Clear();
+        _unitRegistry.Clear();
+        _playerCursorRegistry.Clear();
     }
 
     // --- INetworkRunnerCallbacks Implementation ---
@@ -210,8 +214,8 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
     public void OnShutdown(NetworkRunner runner, ShutdownReason shutdownReason)
     {
         Log($"{GetLogCallPrefix(GetType())} OnShutdown triggered with reason: {shutdownReason}");
-        UnitRegistry.Clear();
-        PlayerCursorRegistry.Clear();
+        _unitRegistry.Clear();
+        _playerCursorRegistry.Clear();
         if (_netRunner != null)
         {
             Destroy(_netRunner);
@@ -223,8 +227,8 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
     public void OnSceneLoadStart(NetworkRunner runner)
     {
         Log($"{GetLogCallPrefix(GetType())} OnSceneLoadStart triggered");
-        UnitRegistry.Clear();
-        PlayerCursorRegistry.Clear();
+        _unitRegistry.Clear();
+        _playerCursorRegistry.Clear();
         // Runner should persist across scene loads; cleanup occurs on shutdown.
     }
 
@@ -248,4 +252,10 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
 
     #endregion
 
+    [Inject]
+    public void Construct(IUnitRegistry unitRegistry, IPlayerCursorRegistry playerCursorRegistry)
+    {
+        _unitRegistry = unitRegistry;
+        _playerCursorRegistry = playerCursorRegistry;
+    }
 }

--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -232,6 +232,22 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
         // Runner should persist across scene loads; cleanup occurs on shutdown.
     }
 
+    /// <summary>
+    /// Performs dependency injection on network objects spawned by Fusion.
+    /// </summary>
+    /// <param name="runner">The active <see cref="NetworkRunner"/>.</param>
+    /// <param name="obj">The spawned network object.</param>
+    public void OnObjectSpawned(NetworkRunner runner, NetworkObject obj)
+    {
+        var scope = FindObjectOfType<ProjectLifetimeScope>();
+        if (scope == null)
+        {
+            return;
+        }
+
+        scope.Container.InjectGameObject(obj.gameObject);
+    }
+
     #region INetworkRunnerCallbacks Implementation Unassigned
 
 

--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -57,6 +57,7 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
 
     private IUnitRegistry _unitRegistry;
     private IPlayerCursorRegistry _playerCursorRegistry;
+    private ProjectLifetimeScope _projectScope;
 
     private void Awake()
     {
@@ -239,13 +240,13 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
     /// <param name="obj">The spawned network object.</param>
     public void OnObjectSpawned(NetworkRunner runner, NetworkObject obj)
     {
-        var scope = FindObjectOfType<ProjectLifetimeScope>();
-        if (scope == null)
+        if (_projectScope == null)
         {
+            LogError($"{GetLogCallPrefix(GetType())} ProjectLifetimeScope was not injected");
             return;
         }
 
-        scope.Container.InjectGameObject(obj.gameObject);
+        _projectScope.Container.InjectGameObject(obj.gameObject);
     }
 
     #region INetworkRunnerCallbacks Implementation Unassigned
@@ -269,9 +270,10 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
     #endregion
 
     [Inject]
-    public void Construct(IUnitRegistry unitRegistry, IPlayerCursorRegistry playerCursorRegistry)
+    public void Construct(IUnitRegistry unitRegistry, IPlayerCursorRegistry playerCursorRegistry, ProjectLifetimeScope projectScope)
     {
         _unitRegistry = unitRegistry;
         _playerCursorRegistry = playerCursorRegistry;
+        _projectScope = projectScope;
     }
 }

--- a/Assets/Scripts/IPlayerCursorRegistry.cs
+++ b/Assets/Scripts/IPlayerCursorRegistry.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Fusion;
+
+/// <summary>
+/// Provides access to active player cursors.
+/// </summary>
+public interface IPlayerCursorRegistry
+{
+    /// <summary>
+    /// All cursors currently tracked by the registry.
+    /// </summary>
+    IEnumerable<PlayerCursor> Cursors { get; }
+
+    /// <summary>
+    /// Registers a cursor for the specified player.
+    /// </summary>
+    void Register(PlayerRef player, PlayerCursor cursor);
+
+    /// <summary>
+    /// Removes the cursor associated with the specified player.
+    /// </summary>
+    void Unregister(PlayerRef player);
+
+    /// <summary>
+    /// Attempts to get the cursor for the specified player.
+    /// </summary>
+    bool TryGet(PlayerRef player, out PlayerCursor cursor);
+
+    /// <summary>
+    /// Clears the registry of all cursors.
+    /// </summary>
+    void Clear();
+}

--- a/Assets/Scripts/IPlayerCursorRegistry.cs.meta
+++ b/Assets/Scripts/IPlayerCursorRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 736e27dfed863294d968a235ffb1749a

--- a/Assets/Scripts/IUnitRegistry.cs
+++ b/Assets/Scripts/IUnitRegistry.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+/// <summary>
+/// Provides access to the collection of active units.
+/// </summary>
+public interface IUnitRegistry
+{
+    /// <summary>
+    /// All units currently tracked by the registry.
+    /// </summary>
+    IEnumerable<Unit> Units { get; }
+
+    /// <summary>
+    /// Registers the specified unit with the given NetworkId.
+    /// </summary>
+    void Register(uint id, Unit unit);
+
+    /// <summary>
+    /// Removes the unit associated with the given NetworkId.
+    /// </summary>
+    void Unregister(uint id);
+
+    /// <summary>
+    /// Attempts to retrieve a unit by its NetworkId.
+    /// </summary>
+    bool TryGet(uint id, out Unit unit);
+
+    /// <summary>
+    /// Clears the registry of all units.
+    /// </summary>
+    void Clear();
+}

--- a/Assets/Scripts/IUnitRegistry.cs.meta
+++ b/Assets/Scripts/IUnitRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 326d92e3d75e3a742a5082e247c58d86

--- a/Assets/Scripts/PlayerCursor.cs
+++ b/Assets/Scripts/PlayerCursor.cs
@@ -2,6 +2,7 @@ using Fusion;
 using UnityEngine;
 using static Corris.Loggers.Logger;
 using static Corris.Loggers.LogUtils;
+using VContainer;
 
 /// <summary>
 /// Networked cursor data for a player.
@@ -16,6 +17,7 @@ public class PlayerCursor : NetworkBehaviour
     public int MaterialIndex { get; set; }
 
     private MeshRenderer _meshRenderer;
+    private IPlayerCursorRegistry _playerCursorRegistry;
 
     /// <summary>
     /// Cached MeshRenderer component of the cursor.
@@ -35,7 +37,7 @@ public class PlayerCursor : NetworkBehaviour
     public override void Spawned()
     {
         base.Spawned();
-        PlayerCursorRegistry.Register(Object.InputAuthority, this);
+        _playerCursorRegistry.Register(Object.InputAuthority, this);
         MaterialApplier.ApplyMaterial(MeshRenderer, MaterialIndex, "Cursor");
     }
 
@@ -46,8 +48,13 @@ public class PlayerCursor : NetworkBehaviour
 
     public override void Despawned(NetworkRunner runner, bool hasState)
     {
-        PlayerCursorRegistry.Unregister(Object.InputAuthority);
+        _playerCursorRegistry.Unregister(Object.InputAuthority);
         base.Despawned(runner, hasState);
     }
 
+    [Inject]
+    public void Construct(IPlayerCursorRegistry playerCursorRegistry)
+    {
+        _playerCursorRegistry = playerCursorRegistry;
+    }
 }

--- a/Assets/Scripts/PlayerCursorRegistry.cs
+++ b/Assets/Scripts/PlayerCursorRegistry.cs
@@ -2,45 +2,47 @@ using System.Collections.Generic;
 using Fusion;
 
 /// <summary>
-/// A static registry for all active player cursors, indexed by PlayerRef.
+/// A registry for all active player cursors, indexed by PlayerRef.
 /// Provides a fast way to look up a player's cursor.
 /// </summary>
-public static class PlayerCursorRegistry
+public class PlayerCursorRegistry : IPlayerCursorRegistry
 {
+    private readonly Dictionary<PlayerRef, PlayerCursor> _cursors = new();
+
     /// <summary>
-    /// The dictionary holding all active cursors. Key is the player's PlayerRef, value is the cursor instance.
+    /// All active cursors.
     /// </summary>
-    public static readonly Dictionary<PlayerRef, PlayerCursor> Cursors = new();
+    public IEnumerable<PlayerCursor> Cursors => _cursors.Values;
 
     /// <summary>
     /// Registers a cursor for the specified player.
     /// </summary>
-    public static void Register(PlayerRef player, PlayerCursor cursor)
+    public void Register(PlayerRef player, PlayerCursor cursor)
     {
-        Cursors[player] = cursor;
+        _cursors[player] = cursor;
     }
 
     /// <summary>
     /// Removes the cursor associated with the specified player.
     /// </summary>
-    public static void Unregister(PlayerRef player)
+    public void Unregister(PlayerRef player)
     {
-        Cursors.Remove(player);
-    }
-
-    /// <summary>
-    /// Clears the registry of all player cursors.
-    /// </summary>
-    public static void Clear()
-    {
-        Cursors.Clear();
+        _cursors.Remove(player);
     }
 
     /// <summary>
     /// Attempts to get the cursor for the specified player.
     /// </summary>
-    public static bool TryGet(PlayerRef player, out PlayerCursor cursor)
+    public bool TryGet(PlayerRef player, out PlayerCursor cursor)
     {
-        return Cursors.TryGetValue(player, out cursor);
+        return _cursors.TryGetValue(player, out cursor);
+    }
+
+    /// <summary>
+    /// Clears the registry of all player cursors.
+    /// </summary>
+    public void Clear()
+    {
+        _cursors.Clear();
     }
 }

--- a/Assets/Scripts/ProjectLifetimeScope.cs
+++ b/Assets/Scripts/ProjectLifetimeScope.cs
@@ -13,6 +13,8 @@ public class ProjectLifetimeScope : LifetimeScope
 
         Log($"{GetLogCallPrefix(GetType())} RegisterComponentInHierarchy!");
 
+        builder.RegisterComponent(this).As<ProjectLifetimeScope>();
+
         builder.RegisterComponentInHierarchy<ConnectionManager>()
             .As<IConnectionService>()
             .As<INetworkEvents>()

--- a/Assets/Scripts/ProjectLifetimeScope.cs
+++ b/Assets/Scripts/ProjectLifetimeScope.cs
@@ -25,5 +25,8 @@ public class ProjectLifetimeScope : LifetimeScope
         builder.RegisterComponentInHierarchy<Panel_Status>();
         builder.RegisterComponentInHierarchy<SelectionManager>();
         builder.RegisterComponentInHierarchy<PlayerManager>();
+
+        builder.Register<UnitRegistry>(Lifetime.Singleton).As<IUnitRegistry>();
+        builder.Register<PlayerCursorRegistry>(Lifetime.Singleton).As<IPlayerCursorRegistry>();
     }
 }

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -29,14 +29,16 @@ public class SelectionManager : MonoBehaviour
 
     private IConnectionService _connectionService;
     private IInputService _inputService;
+    private IUnitRegistry _unitRegistry;
 
     // Called by VContainer to inject the dependency immediately upon its creation.
     [Inject]
-    public void Construct(IConnectionService connectionService, IInputService inputService)
+    public void Construct(IConnectionService connectionService, IInputService inputService, IUnitRegistry unitRegistry)
     {
         Log($"{GetLogCallPrefix(GetType())} VContainer Inject!");
         _connectionService = connectionService;
         _inputService = inputService;
+        _unitRegistry = unitRegistry;
     }
 
     public void Start()
@@ -147,7 +149,7 @@ public class SelectionManager : MonoBehaviour
         Vector2 rightBottom_Screeen = LocalToScreenPoint(mainCamera, _canvasRect, rightBottom_Local);
         Rect selectionBox_Screen = GetRectFromPoints(leftTop_Screen, rightBottom_Screeen);
 
-        foreach (var unit in UnitRegistry.Units.Values)
+        foreach (var unit in _unitRegistry.Units)
         {
             if (unit is not ISelectableProvider { Selectable: { } selectable })
             {

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using static Corris.Loggers.Logger;
 using static Corris.Loggers.LogUtils;
+using VContainer;
 
 /// <summary>
 /// Unit class represents a controllable unit in the game.
@@ -14,6 +15,7 @@ public class Unit : NetworkBehaviour, IPositionable, ISelectableProvider
     public GameObject body;
     private NetworkCharacterController _cc;
     private MeshRenderer _meshRenderer; // Cache for MeshRenderer to avoid repeated lookups
+    private IUnitRegistry _unitRegistry;
 
     /// <summary>
     /// Cached MeshRenderer component of the unit.
@@ -70,14 +72,20 @@ public class Unit : NetworkBehaviour, IPositionable, ISelectableProvider
     public override void Spawned()
     {
         Log($"{GetLogCallPrefix(GetType())} Unit {gameObject.name} spawned.");
-        UnitRegistry.Units[Object.Id.Raw] = this;
+        _unitRegistry.Register(Object.Id.Raw, this);
     }
 
     public override void Despawned(NetworkRunner runner, bool hasState)
     {
         Log($"{GetLogCallPrefix(GetType())} Unit {gameObject.name} despawned. HasState: {hasState}");
-        UnitRegistry.Units.Remove(Object.Id.Raw);
+        _unitRegistry.Unregister(Object.Id.Raw);
         base.Despawned(runner, hasState);
+    }
+
+    [Inject]
+    public void Construct(IUnitRegistry unitRegistry)
+    {
+        _unitRegistry = unitRegistry;
     }
 
     public void SetOwner(PlayerRef newOwner) => PlayerOwner = newOwner;

--- a/Assets/Scripts/UnitRegistry.cs
+++ b/Assets/Scripts/UnitRegistry.cs
@@ -2,22 +2,48 @@
 using System.Collections.Generic;
 
 /// <summary>
-/// A static registry for all active units, indexed by their raw NetworkId value (uint).
+/// A registry for all active units, indexed by their raw NetworkId value (uint).
 /// This provides a high-performance alternative to FindObjectsByType for looking up units.
 /// Units are responsible for registering themselves on spawn and unregistering on despawn.
 /// </summary>
-public static class UnitRegistry
+public class UnitRegistry : IUnitRegistry
 {
+    private readonly Dictionary<uint, Unit> _units = new();
+
     /// <summary>
-    /// The dictionary holding all active units. Key is the unit's raw NetworkId (uint), Value is the unit reference.
+    /// The collection of all active units.
     /// </summary>
-    public static readonly Dictionary<uint, Unit> Units = new();
+    public IEnumerable<Unit> Units => _units.Values;
+
+    /// <summary>
+    /// Registers the specified unit with the given NetworkId.
+    /// </summary>
+    public void Register(uint id, Unit unit)
+    {
+        _units[id] = unit;
+    }
+
+    /// <summary>
+    /// Removes the unit associated with the given NetworkId.
+    /// </summary>
+    public void Unregister(uint id)
+    {
+        _units.Remove(id);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a unit by its NetworkId.
+    /// </summary>
+    public bool TryGet(uint id, out Unit unit)
+    {
+        return _units.TryGetValue(id, out unit);
+    }
 
     /// <summary>
     /// Clears the registry of all units.
     /// </summary>
-    public static void Clear()
+    public void Clear()
     {
-        Units.Clear();
+        _units.Clear();
     }
 }


### PR DESCRIPTION
## Summary
- introduce IUnitRegistry and IPlayerCursorRegistry with DI-friendly implementations
- register registries in ProjectLifetimeScope
- inject registries into classes instead of using static access

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dae2fd2908320b15208a8fa48d25c