### PR TITLE
Use indexable player cursor registry

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2277,6 +2277,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _selectionManager: {fileID: 1096639965}
   _destinationMarkerPrefab: {fileID: 831694046346804455, guid: dd47c8c06480f1448a47302495ee6487, type: 3}
+  _mainCamera: {fileID: 330585545}
   _gameSettings: {fileID: 11400000, guid: 59b9238a41f244fb8096ce8407409de1, type: 2}
   _unitPrefab:
     RawGuidValue: dd098a457d77e9847a3e48cd58d0dfc4
@@ -2720,8 +2721,6 @@ MonoBehaviour:
   buttonSpacing: 2
   buttonWidth: 200
   buttonHeight: 40
-  buttonColor: {r: 0.499288, g: 0.6415094, b: 0.61051244, a: 0.717}
-  menuOffset: {x: 5, y: 5}
   hostButton: {fileID: 560006305}
   joinButton: {fileID: 69457608}
   exitButton: {fileID: 1397237152}

--- a/Assets/Scripts/IPlayerCursorRegistry.cs
+++ b/Assets/Scripts/IPlayerCursorRegistry.cs
@@ -9,7 +9,7 @@ public interface IPlayerCursorRegistry
     /// <summary>
     /// All cursors currently tracked by the registry.
     /// </summary>
-    IEnumerable<PlayerCursor> Cursors { get; }
+    IReadOnlyList<PlayerCursor> Cursors { get; }
 
     /// <summary>
     /// Registers a cursor for the specified player.

--- a/Assets/Scripts/PlayerCursorRegistry.cs
+++ b/Assets/Scripts/PlayerCursorRegistry.cs
@@ -8,17 +8,31 @@ using Fusion;
 public class PlayerCursorRegistry : IPlayerCursorRegistry
 {
     private readonly Dictionary<PlayerRef, PlayerCursor> _cursors = new();
+    private readonly List<PlayerCursor> _cursorList = new();
 
     /// <summary>
     /// All active cursors.
     /// </summary>
-    public IEnumerable<PlayerCursor> Cursors => _cursors.Values;
+    public IReadOnlyList<PlayerCursor> Cursors => _cursorList;
 
     /// <summary>
     /// Registers a cursor for the specified player.
     /// </summary>
     public void Register(PlayerRef player, PlayerCursor cursor)
     {
+        if (_cursors.TryGetValue(player, out var existing))
+        {
+            int index = _cursorList.IndexOf(existing);
+            if (index >= 0)
+            {
+                _cursorList[index] = cursor;
+            }
+        }
+        else
+        {
+            _cursorList.Add(cursor);
+        }
+
         _cursors[player] = cursor;
     }
 
@@ -27,7 +41,11 @@ public class PlayerCursorRegistry : IPlayerCursorRegistry
     /// </summary>
     public void Unregister(PlayerRef player)
     {
-        _cursors.Remove(player);
+        if (_cursors.TryGetValue(player, out var cursor))
+        {
+            _cursorList.Remove(cursor);
+            _cursors.Remove(player);
+        }
     }
 
     /// <summary>
@@ -44,5 +62,6 @@ public class PlayerCursorRegistry : IPlayerCursorRegistry
     public void Clear()
     {
         _cursors.Clear();
+        _cursorList.Clear();
     }
 }

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -168,8 +168,10 @@ public class PlayerManager : NetworkBehaviour
 
     private void UpdateCursorsEcho()
     {
-        foreach (var cursor in _playerCursorRegistry.Cursors)
+        var cursors = _playerCursorRegistry.Cursors;
+        for (int i = 0, count = cursors.Count; i < count; i++)
         {
+            var cursor = cursors[i];
             cursor.transform.position = cursor.CursorPosition;
         }
     }


### PR DESCRIPTION
## Summary
- avoid allocations by exposing player cursors as an `IReadOnlyList`
- maintain internal list for cursors and update iteration logic
- iterate over cursor registry with classic for loop

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f4abe35bc83208351b9fd3d37f430