### PR TITLE
Optimize unit iteration to avoid allocations

### DIFF
--- a/Assets/Scripts/IUnitRegistry.cs
+++ b/Assets/Scripts/IUnitRegistry.cs
@@ -8,7 +8,7 @@ public interface IUnitRegistry
     /// <summary>
     /// All units currently tracked by the registry.
     /// </summary>
-    IEnumerable<Unit> Units { get; }
+    IReadOnlyList<Unit> Units { get; }
 
     /// <summary>
     /// Registers the specified unit with the given NetworkId.

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -149,15 +149,19 @@ public class SelectionManager : MonoBehaviour
         Vector2 rightBottom_Screeen = LocalToScreenPoint(mainCamera, _canvasRect, rightBottom_Local);
         Rect selectionBox_Screen = GetRectFromPoints(leftTop_Screen, rightBottom_Screeen);
 
-        foreach (var unit in _unitRegistry.Units)
+        var units = _unitRegistry.Units;
+        for (int i = 0; i < units.Count; i++)
         {
+            Unit unit = units[i];
             if (unit is not ISelectableProvider { Selectable: { } selectable })
             {
                 continue;
             }
 
             if (!selectable.CanBeSelectedBy(localPlayer))
+            {
                 continue;
+            }
 
             Vector3 unitPosition_Screen = mainCamera.WorldToScreenPoint(unit.Position);
 

--- a/Assets/Scripts/UnitRegistry.cs
+++ b/Assets/Scripts/UnitRegistry.cs
@@ -9,11 +9,12 @@ using System.Collections.Generic;
 public class UnitRegistry : IUnitRegistry
 {
     private readonly Dictionary<uint, Unit> _units = new();
+    private readonly List<Unit> _unitList = new();
 
     /// <summary>
     /// The collection of all active units.
     /// </summary>
-    public IEnumerable<Unit> Units => _units.Values;
+    public IReadOnlyList<Unit> Units => _unitList;
 
     /// <summary>
     /// Registers the specified unit with the given NetworkId.
@@ -21,6 +22,7 @@ public class UnitRegistry : IUnitRegistry
     public void Register(uint id, Unit unit)
     {
         _units[id] = unit;
+        _unitList.Add(unit);
     }
 
     /// <summary>
@@ -28,7 +30,11 @@ public class UnitRegistry : IUnitRegistry
     /// </summary>
     public void Unregister(uint id)
     {
-        _units.Remove(id);
+        if (_units.TryGetValue(id, out Unit unit))
+        {
+            _units.Remove(id);
+            _unitList.Remove(unit);
+        }
     }
 
     /// <summary>
@@ -45,5 +51,6 @@ public class UnitRegistry : IUnitRegistry
     public void Clear()
     {
         _units.Clear();
+        _unitList.Clear();
     }
 }


### PR DESCRIPTION
## Summary
- expose units as `IReadOnlyList<Unit>` for allocation-free enumeration
- maintain an internal list alongside the registry and clear/remove appropriately
- iterate selected units with a for-loop for better performance

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f4e5e1f2c8320bcaa9b4fef86095b