### PR TITLE
Remove legacy static connection events

### DIFF
--- a/Assets/Scripts/ConnectionManager.cs
+++ b/Assets/Scripts/ConnectionManager.cs
@@ -32,10 +32,6 @@ public delegate void OnInputHandler(ref NetworkInputData data);
 public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnectionService, INetworkEvents
 {
     // --- Public Events ---
-    public static event Action OnConnectingStarted; // Temporary for legacy access
-    public static event Action OnConnected; // Temporary for legacy access
-    public static event Action OnDisconnected; // Temporary for legacy access
-
     public event Action ConnectingStarted;
     public event Action Connected;
     public event Action Disconnected;
@@ -148,17 +144,14 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
         {
             _isConnecting = true;
             ConnectingStarted?.Invoke();
-            OnConnectingStarted?.Invoke();
             await StartGameInternal(mode);
             if (_netRunner != null && _netRunner.IsRunning)
             {
                 Connected?.Invoke();
-                OnConnected?.Invoke();
             }
             else
             {
                 Disconnected?.Invoke();
-                OnDisconnected?.Invoke();
             }
         }
         catch (Exception ex)
@@ -207,7 +200,6 @@ public class ConnectionManager : MonoBehaviour, INetworkRunnerCallbacks, IConnec
             _netRunner = null;
         }
         Disconnected?.Invoke();
-        OnDisconnected?.Invoke();
     }
     public void OnSceneLoadStart(NetworkRunner runner)
     {


### PR DESCRIPTION
## Summary
- drop legacy static connection events from `ConnectionManager`
- rely exclusively on instance events for connection lifecycle notifications

## Testing
- `dotnet test` *(fails: MSB1003, no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a05409ec78832093cd3b3ca88ee658