### PR TITLE
Switch player materials to Addressables

### DIFF
--- a/Assets/AddressableAssets/Materials/PlayerMaterialProviderSettings.asset
+++ b/Assets/AddressableAssets/Materials/PlayerMaterialProviderSettings.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f934a730fc3465db0c75e61f5026d01, type: 3}
+  m_Name: PlayerMaterialProviderSettings
+  m_EditorClassIdentifier:
+  _materialListReference:
+    m_AssetGUID: d4ef7b50f3f04675b23f28f84e291aca
+    m_SubObjectName:
+    m_SubObjectType:

--- a/Assets/AddressableAssets/Materials/PlayerMaterialProviderSettings.asset.meta
+++ b/Assets/AddressableAssets/Materials/PlayerMaterialProviderSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a08ba9d34384b4b82a91a39f9c7af4e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1038,7 +1038,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parentReference:
-    TypeName: ProjectLifetimeScope
+    TypeName: 
   autoRun: 1
   autoInjectGameObjects: []
 --- !u!1 &347864834
@@ -2716,7 +2716,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parentReference:
-    TypeName: ProjectLifetimeScope
+    TypeName: 
   autoRun: 1
   autoInjectGameObjects: []
 --- !u!114 &1168897079
@@ -2775,9 +2775,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9af79891b00a33147b3856b6baa951ce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  buttonSpacing: 2
-  buttonWidth: 200
-  buttonHeight: 40
   hostButton: {fileID: 560006305}
   joinButton: {fileID: 69457608}
   exitButton: {fileID: 1397237152}
@@ -3003,6 +3000,7 @@ MonoBehaviour:
     TypeName: 
   autoRun: 1
   autoInjectGameObjects: []
+  _playerMaterialSettings: {fileID: 11400000, guid: 0a08ba9d34384b4b82a91a39f9c7af4e, type: 2}
 --- !u!1 &1620159955
 GameObject:
   m_ObjectHideFlags: 0
@@ -3121,7 +3119,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parentReference:
-    TypeName: ProjectLifetimeScope
+    TypeName: 
   autoRun: 1
   autoInjectGameObjects: []
 --- !u!1 &1932837410
@@ -3174,7 +3172,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parentReference:
-    TypeName: ProjectLifetimeScope
+    TypeName: 
   autoRun: 1
   autoInjectGameObjects: []
 --- !u!1660057539 &9223372036854775807

--- a/Assets/Scripts/Gameplay/PlayerCursor.cs
+++ b/Assets/Scripts/Gameplay/PlayerCursor.cs
@@ -51,12 +51,12 @@ namespace FusionTask.Gameplay
             }
 
             _playerCursorRegistry.Register(Object.InputAuthority, this);
-            MaterialApplier.ApplyMaterial(MeshRenderer, MaterialIndex, "Cursor");
+            _ = MaterialApplier.ApplyMaterialAsync(MeshRenderer, MaterialIndex, "Cursor");
         }
 
         private void OnMaterialIndexChanged()
         {
-            MaterialApplier.ApplyMaterial(MeshRenderer, MaterialIndex, "Cursor");
+            _ = MaterialApplier.ApplyMaterialAsync(MeshRenderer, MaterialIndex, "Cursor");
         }
 
         public override void Despawned(NetworkRunner runner, bool hasState)

--- a/Assets/Scripts/Gameplay/PlayerManager.cs
+++ b/Assets/Scripts/Gameplay/PlayerManager.cs
@@ -405,7 +405,7 @@ namespace FusionTask.Gameplay
                 if (networkObject != null && networkObject.TryGetComponent<Unit>(out var unit))
                 {
                     unit.materialIndex = index;
-                    MaterialApplier.ApplyMaterial(unit.MeshRenderer, index, "Unit");
+                    _ = MaterialApplier.ApplyMaterialAsync(unit.MeshRenderer, index, "Unit");
                     unit.RPC_RelaySpawnedUnitInfo(unit.name, index);
                 }
             }

--- a/Assets/Scripts/Gameplay/Unit.cs
+++ b/Assets/Scripts/Gameplay/Unit.cs
@@ -1,6 +1,7 @@
 using Fusion;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UnityEngine;
 using static Corris.Loggers.Logger;
 using static Corris.Loggers.LogUtils;
@@ -210,13 +211,13 @@ namespace FusionTask.Gameplay
     /// </summary>
     /// <param name="unitName">Name of the unit.</param>
     /// <param name="materialIndex">Material index to apply.</param>
-    private void ApplyUnitInfo(String unitName, int materialIndex)
+    private async Task ApplyUnitInfo(String unitName, int materialIndex)
     {
         Log($"{GetLogCallPrefix(GetType())} RPC_RelaySpawnedUnitInfo {unitName}");
 
         name = unitName;
         this.materialIndex = materialIndex;
-        MaterialApplier.ApplyMaterial(MeshRenderer, materialIndex, "Unit");
+        await MaterialApplier.ApplyMaterialAsync(MeshRenderer, materialIndex, "Unit");
     }
 
     /// <summary>
@@ -227,7 +228,7 @@ namespace FusionTask.Gameplay
     [Rpc(RpcSources.StateAuthority, RpcTargets.All, HostMode = RpcHostMode.SourceIsServer, Channel = RpcChannel.Reliable)]
     public void RPC_RelaySpawnedUnitInfo(String unitName, int materialIndex)
     {
-        ApplyUnitInfo(unitName, materialIndex);
+        _ = ApplyUnitInfo(unitName, materialIndex);
     }
 
     /// <summary>
@@ -239,7 +240,7 @@ namespace FusionTask.Gameplay
     [Rpc(RpcSources.StateAuthority, RpcTargets.All, HostMode = RpcHostMode.SourceIsServer, Channel = RpcChannel.Reliable)]
     public void RPC_RelaySpawnedUnitInfoToPlayer([RpcTarget] PlayerRef targetPlayer, String unitName, int materialIndex)
     {
-        ApplyUnitInfo(unitName, materialIndex);
+        _ = ApplyUnitInfo(unitName, materialIndex);
     }
     }
 }

--- a/Assets/Scripts/Infrastructure/MaterialApplier.cs
+++ b/Assets/Scripts/Infrastructure/MaterialApplier.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using UnityEngine;
 using static Corris.Loggers.Logger;
 using static Corris.Loggers.LogUtils;
@@ -27,6 +28,41 @@ namespace FusionTask.Infrastructure
             }
 
             var material = PlayerMaterialProvider.GetMaterial(index);
+
+            if (material == null)
+            {
+                LogError($"{GetLogCallPrefix(typeof(MaterialApplier))} Material not found for {entityName} Index[{index}].");
+                return false;
+            }
+
+            renderer.sharedMaterial = material;
+
+            if (propertyBlock != null)
+            {
+                renderer.SetPropertyBlock(propertyBlock);
+            }
+
+            Log($"{GetLogCallPrefix(typeof(MaterialApplier))} Material successfully loaded and applied to {entityName} Index[{index}].");
+            return true;
+        }
+
+        /// <summary>
+        /// Asynchronously applies a material to the given mesh renderer using the material index.
+        /// </summary>
+        /// <param name="renderer">The MeshRenderer to apply the material to.</param>
+        /// <param name="index">The material index used to retrieve the material.</param>
+        /// <param name="entityName">Name of the entity for logging purposes.</param>
+        /// <param name="propertyBlock">Optional property block for per-instance material properties.</param>
+        /// <returns>True if the material was successfully applied, otherwise false.</returns>
+        public static async Task<bool> ApplyMaterialAsync(MeshRenderer renderer, int index, string entityName, MaterialPropertyBlock propertyBlock = null)
+        {
+            if (renderer == null)
+            {
+                LogError($"{GetLogCallPrefix(typeof(MaterialApplier))} MeshRenderer not found for {entityName} Index[{index}].");
+                return false;
+            }
+
+            var material = await PlayerMaterialProvider.GetMaterialAsync(index);
 
             if (material == null)
             {

--- a/Assets/Scripts/Infrastructure/PlayerMaterialProviderSettings.cs
+++ b/Assets/Scripts/Infrastructure/PlayerMaterialProviderSettings.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace FusionTask.Infrastructure
+{
+    /// <summary>
+    /// Provides configuration for <see cref="PlayerMaterialProvider"/>.
+    /// Contains an Addressables reference to the list of player materials.
+    /// </summary>
+    [CreateAssetMenu(fileName = "PlayerMaterialProviderSettings", menuName = "Config/Player Material Provider Settings")]
+    public class PlayerMaterialProviderSettings : ScriptableObject
+    {
+        [SerializeField] private AssetReferenceT<PlayerMaterialList> _materialListReference;
+
+        /// <summary>
+        /// Addressable reference to the <see cref="PlayerMaterialList"/> asset.
+        /// </summary>
+        public AssetReferenceT<PlayerMaterialList> MaterialListReference => _materialListReference;
+    }
+}

--- a/Assets/Scripts/Infrastructure/PlayerMaterialProviderSettings.cs.meta
+++ b/Assets/Scripts/Infrastructure/PlayerMaterialProviderSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f934a730fc3465db0c75e61f5026d01

--- a/Assets/Scripts/Infrastructure/ProjectLifetimeScope.cs
+++ b/Assets/Scripts/Infrastructure/ProjectLifetimeScope.cs
@@ -1,3 +1,4 @@
+using UnityEngine;
 using VContainer;
 using VContainer.Unity;
 using static Corris.Loggers.Logger;

--- a/Assets/Scripts/Infrastructure/ProjectLifetimeScope.cs
+++ b/Assets/Scripts/Infrastructure/ProjectLifetimeScope.cs
@@ -13,6 +13,8 @@ namespace FusionTask.Infrastructure
     /// </summary>
     public class ProjectLifetimeScope : LifetimeScope
     {
+        [SerializeField] private PlayerMaterialProviderSettings _playerMaterialSettings;
+
         protected override void Awake()
         {
             // Initialize the bridge as soon as the scope is awake.
@@ -42,6 +44,14 @@ namespace FusionTask.Infrastructure
 
             builder.Register<UnitRegistry>(Lifetime.Singleton).As<IUnitRegistry>();
             builder.Register<PlayerCursorRegistry>(Lifetime.Singleton).As<IPlayerCursorRegistry>();
+
+            PlayerMaterialProvider.Initialize(_playerMaterialSettings);
+        }
+
+        protected override void OnDestroy()
+        {
+            PlayerMaterialProvider.Release();
+            base.OnDestroy();
         }
     }
 }

--- a/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -33,24 +33,24 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 2644742549224554758
-      - rid: 2644742549224554759
+      - rid: 2644742549224554781
+      - rid: 2644742549224554782
       - rid: 6852985685364965378
       - rid: 6852985685364965379
       - rid: 6852985685364965380
       - rid: 6852985685364965381
-      - rid: 2644742549224554760
-      - rid: 2644742549224554761
+      - rid: 2644742549224554783
+      - rid: 2644742549224554784
       - rid: 6852985685364965384
       - rid: 6852985685364965385
-      - rid: 2644742549224554762
-      - rid: 2644742549224554763
-      - rid: 2644742549224554764
-      - rid: 2644742549224554765
-      - rid: 2644742549224554766
-      - rid: 2644742549224554767
+      - rid: 2644742549224554785
+      - rid: 2644742549224554786
+      - rid: 2644742549224554787
+      - rid: 2644742549224554788
+      - rid: 2644742549224554789
+      - rid: 2644742549224554790
       - rid: 6852985685364965392
-      - rid: 2644742549224554768
+      - rid: 2644742549224554791
       - rid: 6852985685364965394
       - rid: 8712630790384254976
       - rid: 196572100355162112
@@ -102,14 +102,14 @@ MonoBehaviour:
         m_xrOcclusionMeshPS: {fileID: 4800000, guid: 4431b1f1f743fbf4eb310a967890cbea, type: 3}
         m_xrMirrorViewPS: {fileID: 4800000, guid: d5a307c014552314b9f560906d708772, type: 3}
         m_xrMotionVector: {fileID: 4800000, guid: f89aac1e4f84468418fe30e611dff395, type: 3}
-    - rid: 2644742549224554758
+    - rid: 2644742549224554781
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 1
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 2644742549224554759
+    - rid: 2644742549224554782
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -121,7 +121,7 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 2644742549224554760
+    - rid: 2644742549224554783
       type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -136,7 +136,7 @@ MonoBehaviour:
         m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
         m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
         m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 2644742549224554761
+    - rid: 2644742549224554784
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -144,7 +144,7 @@ MonoBehaviour:
         m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
-    - rid: 2644742549224554762
+    - rid: 2644742549224554785
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -157,13 +157,13 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 2644742549224554763
+    - rid: 2644742549224554786
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 2644742549224554764
+    - rid: 2644742549224554787
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -176,12 +176,12 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 2644742549224554765
+    - rid: 2644742549224554788
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 2644742549224554766
+    - rid: 2644742549224554789
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -191,14 +191,14 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 2644742549224554767
+    - rid: 2644742549224554790
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 2644742549224554768
+    - rid: 2644742549224554791
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1


### PR DESCRIPTION
## Summary
- add PlayerMaterialProviderSettings ScriptableObject for Addressables references
- load and cache materials via Addressables with release support
- apply materials asynchronously across gameplay scripts

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0aca13920832091732146ee9ac9ac