### PR TITLE
Refactor player material provider to DI service

### DIFF
--- a/Assets/Scripts/Gameplay/PlayerCursor.cs
+++ b/Assets/Scripts/Gameplay/PlayerCursor.cs
@@ -21,6 +21,7 @@ namespace FusionTask.Gameplay
 
         private MeshRenderer _meshRenderer;
         private IPlayerCursorRegistry _playerCursorRegistry;
+        private IMaterialApplier _materialApplier;
 
         /// <summary>
         /// Cached MeshRenderer component of the cursor.
@@ -51,12 +52,12 @@ namespace FusionTask.Gameplay
             }
 
             _playerCursorRegistry.Register(Object.InputAuthority, this);
-            _ = MaterialApplier.ApplyMaterialAsync(MeshRenderer, MaterialIndex, "Cursor");
+            _ = _materialApplier.ApplyMaterialAsync(MeshRenderer, MaterialIndex, "Cursor");
         }
 
         private void OnMaterialIndexChanged()
         {
-            _ = MaterialApplier.ApplyMaterialAsync(MeshRenderer, MaterialIndex, "Cursor");
+            _ = _materialApplier.ApplyMaterialAsync(MeshRenderer, MaterialIndex, "Cursor");
         }
 
         public override void Despawned(NetworkRunner runner, bool hasState)
@@ -66,9 +67,10 @@ namespace FusionTask.Gameplay
         }
 
         [Inject]
-        public void Construct(IPlayerCursorRegistry playerCursorRegistry)
+        public void Construct(IPlayerCursorRegistry playerCursorRegistry, IMaterialApplier materialApplier)
         {
             _playerCursorRegistry = playerCursorRegistry;
+            _materialApplier = materialApplier;
         }
     }
 }

--- a/Assets/Scripts/Gameplay/PlayerManager.cs
+++ b/Assets/Scripts/Gameplay/PlayerManager.cs
@@ -59,9 +59,10 @@ namespace FusionTask.Gameplay
     private IUnitRegistry _unitRegistry;
     private IPlayerCursorRegistry _playerCursorRegistry;
     private IObjectResolver _resolver;
+    private IMaterialApplier _materialApplier;
 
     [Inject]
-    public void Construct(IConnectionService connectionService, INetworkEvents networkEvents, IInputService inputService, IUnitRegistry unitRegistry, IPlayerCursorRegistry playerCursorRegistry, IObjectResolver resolver)
+    public void Construct(IConnectionService connectionService, INetworkEvents networkEvents, IInputService inputService, IUnitRegistry unitRegistry, IPlayerCursorRegistry playerCursorRegistry, IObjectResolver resolver, IMaterialApplier materialApplier)
     {
         Log($"{GetLogCallPrefix(GetType())} VContainer Inject!");
         _connectionService = connectionService;
@@ -70,6 +71,7 @@ namespace FusionTask.Gameplay
         _unitRegistry = unitRegistry;
         _playerCursorRegistry = playerCursorRegistry;
         _resolver = resolver;
+        _materialApplier = materialApplier;
     }
 
     private void Awake()
@@ -405,7 +407,7 @@ namespace FusionTask.Gameplay
                 if (networkObject != null && networkObject.TryGetComponent<Unit>(out var unit))
                 {
                     unit.materialIndex = index;
-                    _ = MaterialApplier.ApplyMaterialAsync(unit.MeshRenderer, index, "Unit");
+                    _ = _materialApplier.ApplyMaterialAsync(unit.MeshRenderer, index, "Unit");
                     unit.RPC_RelaySpawnedUnitInfo(unit.name, index);
                 }
             }

--- a/Assets/Scripts/Gameplay/Unit.cs
+++ b/Assets/Scripts/Gameplay/Unit.cs
@@ -20,6 +20,7 @@ namespace FusionTask.Gameplay
     private NetworkCharacterController _cc;
     private MeshRenderer _meshRenderer; // Cache for MeshRenderer to avoid repeated lookups
     private IUnitRegistry _unitRegistry;
+    private IMaterialApplier _materialApplier;
 
     /// <summary>
     /// Cached MeshRenderer component of the unit.
@@ -100,9 +101,10 @@ namespace FusionTask.Gameplay
     }
 
     [Inject]
-    public void Construct(IUnitRegistry unitRegistry)
+    public void Construct(IUnitRegistry unitRegistry, IMaterialApplier materialApplier)
     {
         _unitRegistry = unitRegistry;
+        _materialApplier = materialApplier;
     }
 
     public void SetOwner(PlayerRef newOwner) => PlayerOwner = newOwner;
@@ -217,7 +219,7 @@ namespace FusionTask.Gameplay
 
         name = unitName;
         this.materialIndex = materialIndex;
-        await MaterialApplier.ApplyMaterialAsync(MeshRenderer, materialIndex, "Unit");
+        await _materialApplier.ApplyMaterialAsync(MeshRenderer, materialIndex, "Unit");
     }
 
     /// <summary>

--- a/Assets/Scripts/Infrastructure/IMaterialApplier.cs
+++ b/Assets/Scripts/Infrastructure/IMaterialApplier.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace FusionTask.Infrastructure
+{
+    /// <summary>
+    /// Applies materials to mesh renderers.
+    /// </summary>
+    public interface IMaterialApplier
+    {
+        /// <summary>
+        /// Applies a material by index to the given renderer.
+        /// </summary>
+        /// <param name="renderer">Target mesh renderer.</param>
+        /// <param name="index">Material index.</param>
+        /// <param name="entityName">Name for logging.</param>
+        /// <param name="propertyBlock">Optional property block.</param>
+        /// <returns>True if material applied; otherwise false.</returns>
+        bool ApplyMaterial(MeshRenderer renderer, int index, string entityName, MaterialPropertyBlock propertyBlock = null);
+
+        /// <summary>
+        /// Asynchronously applies a material by index to the given renderer.
+        /// </summary>
+        /// <param name="renderer">Target mesh renderer.</param>
+        /// <param name="index">Material index.</param>
+        /// <param name="entityName">Name for logging.</param>
+        /// <param name="propertyBlock">Optional property block.</param>
+        /// <returns>True if material applied; otherwise false.</returns>
+        Task<bool> ApplyMaterialAsync(MeshRenderer renderer, int index, string entityName, MaterialPropertyBlock propertyBlock = null);
+    }
+}

--- a/Assets/Scripts/Infrastructure/IMaterialApplier.cs.meta
+++ b/Assets/Scripts/Infrastructure/IMaterialApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1cb81fee8e24a01b0d38c89f04755cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Infrastructure/IPlayerMaterialProvider.cs
+++ b/Assets/Scripts/Infrastructure/IPlayerMaterialProvider.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace FusionTask.Infrastructure
+{
+    /// <summary>
+    /// Provides player materials and manages their lifecycle.
+    /// </summary>
+    public interface IPlayerMaterialProvider
+    {
+        /// <summary>
+        /// Asynchronously retrieves a material by index.
+        /// </summary>
+        /// <param name="index">Index of the material in the list.</param>
+        /// <returns>The material if found; otherwise null.</returns>
+        Task<Material> GetMaterialAsync(int index);
+
+        /// <summary>
+        /// Retrieves a material by index, loading it if necessary.
+        /// </summary>
+        /// <param name="index">Index of the material in the list.</param>
+        /// <returns>The material if found; otherwise null.</returns>
+        Material GetMaterial(int index);
+
+        /// <summary>
+        /// Releases cached resources.
+        /// </summary>
+        void Release();
+    }
+}

--- a/Assets/Scripts/Infrastructure/IPlayerMaterialProvider.cs.meta
+++ b/Assets/Scripts/Infrastructure/IPlayerMaterialProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a49b7697901f4f868ccb3f63c1406088
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Infrastructure/MaterialApplier.cs
+++ b/Assets/Scripts/Infrastructure/MaterialApplier.cs
@@ -8,8 +8,19 @@ namespace FusionTask.Infrastructure
     /// <summary>
     /// Provides utility methods for applying materials to mesh renderers.
     /// </summary>
-    public static class MaterialApplier
+    public class MaterialApplier : IMaterialApplier
     {
+        private readonly IPlayerMaterialProvider _playerMaterialProvider;
+
+        /// <summary>
+        /// Creates a new material applier.
+        /// </summary>
+        /// <param name="playerMaterialProvider">Provider for retrieving materials.</param>
+        public MaterialApplier(IPlayerMaterialProvider playerMaterialProvider)
+        {
+            _playerMaterialProvider = playerMaterialProvider;
+        }
+
         /// <summary>
         /// Applies a material to the given mesh renderer using the material index.
         /// Logs errors or success messages using the provided entity name.
@@ -19,7 +30,7 @@ namespace FusionTask.Infrastructure
         /// <param name="entityName">Name of the entity for logging purposes.</param>
         /// <param name="propertyBlock">Optional property block for per-instance material properties.</param>
         /// <returns>True if the material was successfully applied, otherwise false.</returns>
-        public static bool ApplyMaterial(MeshRenderer renderer, int index, string entityName, MaterialPropertyBlock propertyBlock = null)
+        public bool ApplyMaterial(MeshRenderer renderer, int index, string entityName, MaterialPropertyBlock propertyBlock = null)
         {
             if (renderer == null)
             {
@@ -27,7 +38,7 @@ namespace FusionTask.Infrastructure
                 return false;
             }
 
-            var material = PlayerMaterialProvider.GetMaterial(index);
+            var material = _playerMaterialProvider.GetMaterial(index);
 
             if (material == null)
             {
@@ -54,7 +65,7 @@ namespace FusionTask.Infrastructure
         /// <param name="entityName">Name of the entity for logging purposes.</param>
         /// <param name="propertyBlock">Optional property block for per-instance material properties.</param>
         /// <returns>True if the material was successfully applied, otherwise false.</returns>
-        public static async Task<bool> ApplyMaterialAsync(MeshRenderer renderer, int index, string entityName, MaterialPropertyBlock propertyBlock = null)
+        public async Task<bool> ApplyMaterialAsync(MeshRenderer renderer, int index, string entityName, MaterialPropertyBlock propertyBlock = null)
         {
             if (renderer == null)
             {
@@ -62,7 +73,7 @@ namespace FusionTask.Infrastructure
                 return false;
             }
 
-            var material = await PlayerMaterialProvider.GetMaterialAsync(index);
+            var material = await _playerMaterialProvider.GetMaterialAsync(index);
 
             if (material == null)
             {

--- a/Assets/Scripts/Infrastructure/PlayerMaterialProvider.cs
+++ b/Assets/Scripts/Infrastructure/PlayerMaterialProvider.cs
@@ -9,19 +9,19 @@ namespace FusionTask.Infrastructure
     /// <summary>
     /// Provides player materials via Addressables and caches them to avoid duplicate loading.
     /// </summary>
-    public static class PlayerMaterialProvider
+    public class PlayerMaterialProvider : IPlayerMaterialProvider
     {
-        private static PlayerMaterialProviderSettings _settings;
-        private static AsyncOperationHandle<PlayerMaterialList> _handle;
+        private readonly PlayerMaterialProviderSettings _settings;
+        private AsyncOperationHandle<PlayerMaterialList> _handle;
 
-        private static readonly Dictionary<int, Material> _materials = new();
-        private static PlayerMaterialList _materialList;
+        private readonly Dictionary<int, Material> _materials = new();
+        private PlayerMaterialList _materialList;
 
         /// <summary>
         /// Initializes the provider with configuration settings.
         /// </summary>
         /// <param name="settings">Settings containing the Addressable reference to the material list.</param>
-        public static void Initialize(PlayerMaterialProviderSettings settings)
+        public PlayerMaterialProvider(PlayerMaterialProviderSettings settings)
         {
             _settings = settings;
         }
@@ -31,7 +31,7 @@ namespace FusionTask.Infrastructure
         /// </summary>
         /// <param name="index">Index of the material in the list.</param>
         /// <returns>The loaded material or null if not found.</returns>
-        public static async Task<Material> GetMaterialAsync(int index)
+        public async Task<Material> GetMaterialAsync(int index)
         {
             if (_settings == null || _settings.MaterialListReference == null)
                 return null;
@@ -52,7 +52,7 @@ namespace FusionTask.Infrastructure
         /// <summary>
         /// Returns a material for the given index. The material is loaded once and then cached.
         /// </summary>
-        public static Material GetMaterial(int index)
+        public Material GetMaterial(int index)
         {
             if (_materials.TryGetValue(index, out var material) && material != null)
             {
@@ -87,7 +87,7 @@ namespace FusionTask.Infrastructure
         /// <summary>
         /// Releases loaded Addressable resources and clears caches.
         /// </summary>
-        public static void Release()
+        public void Release()
         {
             if (_handle.IsValid())
             {

--- a/Assets/Scripts/Infrastructure/ProjectLifetimeScope.cs
+++ b/Assets/Scripts/Infrastructure/ProjectLifetimeScope.cs
@@ -15,6 +15,7 @@ namespace FusionTask.Infrastructure
     public class ProjectLifetimeScope : LifetimeScope
     {
         [SerializeField] private PlayerMaterialProviderSettings _playerMaterialSettings;
+        private IPlayerMaterialProvider _playerMaterialProvider;
 
         protected override void Awake()
         {
@@ -46,12 +47,19 @@ namespace FusionTask.Infrastructure
             builder.Register<UnitRegistry>(Lifetime.Singleton).As<IUnitRegistry>();
             builder.Register<PlayerCursorRegistry>(Lifetime.Singleton).As<IPlayerCursorRegistry>();
 
-            PlayerMaterialProvider.Initialize(_playerMaterialSettings);
+            builder.RegisterInstance(_playerMaterialSettings);
+            builder.Register<PlayerMaterialProvider>(Lifetime.Singleton).As<IPlayerMaterialProvider>();
+            builder.Register<MaterialApplier>(Lifetime.Singleton).As<IMaterialApplier>();
+
+            builder.RegisterBuildCallback(container =>
+            {
+                _playerMaterialProvider = container.Resolve<IPlayerMaterialProvider>();
+            });
         }
 
         protected override void OnDestroy()
         {
-            PlayerMaterialProvider.Release();
+            _playerMaterialProvider.Release();
             base.OnDestroy();
         }
     }


### PR DESCRIPTION
## Summary
- introduce `IPlayerMaterialProvider` and `IMaterialApplier` interfaces
- convert material provider and applier to DI services
- inject new services into gameplay components and register in `ProjectLifetimeScope`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a2da46448320a2d4f87e3781588a