### PR TITLE
Support player unit respawn at original spawn point

### DIFF
--- a/Assets/Scripts/Infrastructure/IInputService.cs
+++ b/Assets/Scripts/Infrastructure/IInputService.cs
@@ -13,5 +13,6 @@ namespace FusionTask.Infrastructure
         event Action OnPrimaryMouseUp;
         event Action<Vector3> OnSecondaryMouseClick_World;
         event Action<Vector3> OnMouseMove;
+        event Action OnRespawn;
     }
 }

--- a/Assets/Scripts/Infrastructure/InputManager.cs
+++ b/Assets/Scripts/Infrastructure/InputManager.cs
@@ -20,6 +20,7 @@ namespace FusionTask.Infrastructure
 
     // --- Mouse movement  ---
     public event Action<Vector3> OnMouseMove;
+    public event Action OnRespawn;
 
     // Camera used for raycasting
     [SerializeField] private Camera mainCamera;
@@ -33,6 +34,7 @@ namespace FusionTask.Infrastructure
         ProcessPrimaryMouseInput();
         ProcessSecondaryMouseInput();
         ProcessMousePosition();
+        ProcessRespawnInput();
     }
 
     /// <summary>
@@ -80,6 +82,17 @@ namespace FusionTask.Infrastructure
     private void ProcessMousePosition()
     {
         OnMouseMove?.Invoke(Input.mousePosition);
+    }
+
+    /// <summary>
+    /// Detects the spacebar press for the respawn command.
+    /// </summary>
+    private void ProcessRespawnInput()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            OnRespawn?.Invoke();
+        }
     }
 
     }


### PR DESCRIPTION
## Summary
- broadcast a respawn input event from the input service
- store initial spawn positions and handle respawn requests
- unify player unit spawning so initial spawn and respawn reuse the same logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f2a568dc832086026fcd49665386