### PR TITLE
Add Unit reach distance tests

### DIFF
--- a/Assets/Tests/Editor/UnitMathTests.cs
+++ b/Assets/Tests/Editor/UnitMathTests.cs
@@ -53,7 +53,7 @@ namespace FusionTask.Tests.Editor
         public void HasReachedTarget_ReturnsTrueWhenFarAwayOnYAxis()
         {
             Vector3 target = new Vector3(5f, 0f, 5f);
-            _gameObject.transform.position = new Vector3(5.8f, 100f, 5.6f); // Far on Y but within 1 unit on XZ
+            _gameObject.transform.position = new Vector3(5.7f, 100f, 5.6f); // Far on Y but within 1 unit on XZ
 
             bool reached = (bool)_hasReachedTargetMethod.Invoke(_unit, new object[] { target });
 

--- a/Assets/Tests/Editor/UnitMathTests.cs
+++ b/Assets/Tests/Editor/UnitMathTests.cs
@@ -37,5 +37,27 @@ namespace FusionTask.Tests.Editor
 
             Assert.IsTrue(reached);
         }
+
+        [Test]
+        public void HasReachedTarget_ReturnsFalseBeyondOneUnitRadiusXZ()
+        {
+            Vector3 target = new Vector3(5f, 0f, 5f);
+            _gameObject.transform.position = new Vector3(7f, 0f, 5f); // Distance on X axis is 2 units
+
+            bool reached = (bool)_hasReachedTargetMethod.Invoke(_unit, new object[] { target });
+
+            Assert.IsFalse(reached);
+        }
+
+        [Test]
+        public void HasReachedTarget_ReturnsTrueWhenFarAwayOnYAxis()
+        {
+            Vector3 target = new Vector3(5f, 0f, 5f);
+            _gameObject.transform.position = new Vector3(5.8f, 100f, 5.6f); // Far on Y but within 1 unit on XZ
+
+            bool reached = (bool)_hasReachedTargetMethod.Invoke(_unit, new object[] { target });
+
+            Assert.IsTrue(reached);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add tests for HasReachedTarget when unit exceeds XZ radius
- ensure Y distance is ignored in HasReachedTarget

## Testing
- `dotnet test` *(fails: MSB1003 no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a33fe3505c8320a73dfd9198c1b9f0