### PR TITLE
Add unit tests for AsyncObjectPool

### DIFF
--- a/Assets/Tests/Editor/AsyncObjectPoolTests.cs
+++ b/Assets/Tests/Editor/AsyncObjectPoolTests.cs
@@ -1,0 +1,92 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using FusionTask.Infrastructure;
+
+namespace FusionTask.Tests.Editor
+{
+    /// <summary>
+    /// Tests for the AsyncObjectPool functionality.
+    /// </summary>
+    public class AsyncObjectPoolTests
+    {
+        private class TestComponent : MonoBehaviour
+        {
+        }
+
+        [Test]
+        public async Task Get_ReturnsActiveObject_WhenPoolIsEmpty()
+        {
+            async Task<TestComponent> Factory()
+            {
+                await Task.Yield();
+                var go = new GameObject();
+                return go.AddComponent<TestComponent>();
+            }
+
+            var pool = new AsyncObjectPool<TestComponent>(Factory);
+
+            var instance = await pool.Get();
+
+            Assert.IsTrue(instance.gameObject.activeSelf);
+            Assert.IsFalse(instance.IsNullOrDestroyed());
+
+            Object.DestroyImmediate(instance.gameObject);
+        }
+
+        [Test]
+        public async Task Release_DisablesObject_And_GetReturnsSameInstance()
+        {
+            async Task<TestComponent> Factory()
+            {
+                await Task.Yield();
+                var go = new GameObject();
+                return go.AddComponent<TestComponent>();
+            }
+
+            var pool = new AsyncObjectPool<TestComponent>(Factory);
+
+            var first = await pool.Get();
+            pool.Release(first);
+
+            Assert.IsFalse(first.gameObject.activeSelf);
+
+            var second = await pool.Get();
+
+            Assert.AreSame(first, second);
+            Assert.IsTrue(second.gameObject.activeSelf);
+
+            Object.DestroyImmediate(second.gameObject);
+        }
+
+        [Test]
+        public async Task Warmup_CreatesAndStoresSpecifiedNumberOfObjects()
+        {
+            int counter = 0;
+
+            async Task<TestComponent> Factory()
+            {
+                counter++;
+                await Task.Yield();
+                var go = new GameObject();
+                return go.AddComponent<TestComponent>();
+            }
+
+            var pool = new AsyncObjectPool<TestComponent>(Factory);
+
+            const int count = 3;
+            await pool.Warmup(count);
+
+            Assert.AreEqual(count, counter);
+
+            for (int i = 0; i < count; i++)
+            {
+                var instance = await pool.Get();
+                Assert.IsTrue(instance.gameObject.activeSelf);
+                Object.DestroyImmediate(instance.gameObject);
+            }
+
+            Assert.AreEqual(count, counter);
+        }
+    }
+}

--- a/Assets/Tests/Editor/AsyncObjectPoolTests.cs.meta
+++ b/Assets/Tests/Editor/AsyncObjectPoolTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53398635411c4ca5858a908d79504fd8


### PR DESCRIPTION
## Summary
- add AsyncObjectPoolTests covering object retrieval, release, and warmup behaviors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a340197c148320ad73bc9df1438dc0